### PR TITLE
feat: 보이스팩 사용권 획득 API 및 관련 데이터 모델 추가

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -42,3 +42,4 @@ out/
 ### resources ###
 application.properties
 application.yaml
+application-local.yaml

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackController.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackController.kt
@@ -192,7 +192,7 @@ class VoicepackController(
             )
         ]
     )
-    @PostMapping("/grant-usage-right")
+    @PostMapping("/usage-right")
     fun grantUsageRight(
         @Parameter(description = "사용자 ID") @RequestParam userId: Long,
         @Parameter(description = "보이스팩 ID") @RequestParam voicepackId: Long
@@ -232,7 +232,7 @@ class VoicepackController(
             )
         ]
     )
-    @GetMapping("/user-voicepacks")
+    @GetMapping("/usage-right")
     fun getUserVoicepacks(
         @Parameter(description = "사용자 ID") @RequestParam userId: Long
     ): ResponseEntity<List<VoicepackUsageRightBriefDto>> {

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackController.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackController.kt
@@ -1,6 +1,7 @@
 package kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack
 
 import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.dto.*
+import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.usageright.VoicepackUsageRightDto
 import org.springframework.http.ResponseEntity
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
@@ -161,5 +162,56 @@ class VoicepackController(
         } catch (e: IllegalArgumentException) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(null)
         }
-    }   
+    }
+
+    @Operation(
+        summary = "보이스팩 사용권 획득",
+        description = "사용자가 특정 보이스팩의 사용권을 획득합니다 (구매 또는 제작자 자동 획득).",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "사용권 획득 성공",
+                content = [Content(schema = Schema(implementation = VoicepackUsageRightDto::class))]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청 (예: 사용자 또는 보이스팩 없음)"
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "이미 사용권을 가지고 있는 보이스팩"
+            ),
+            ApiResponse(
+                responseCode = "402",
+                description = "크레딧 부족 (크레딧 연동 시)"
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "서버 오류"
+            )
+        ]
+    )
+    @PostMapping("/grant-usage-right")
+    fun grantUsageRight(
+        @Parameter(description = "사용자 ID") @RequestParam userId: Long,
+        @Parameter(description = "보이스팩 ID") @RequestParam voicepackId: Long
+    ): ResponseEntity<Any> {
+        try {
+            val usageRightDto = voicepackService.grantUsageRight(userId, voicepackId)
+            return ResponseEntity.ok(usageRightDto)
+        } catch (e: IllegalArgumentException) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(mapOf("error" to e.message))
+        } catch (e: IllegalStateException) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(mapOf("error" to e.message))
+        } catch (e: RuntimeException) {
+            if (e.message?.contains("크레딧") == true) {
+                return ResponseEntity.status(HttpStatus.PAYMENT_REQUIRED).body(mapOf("error" to e.message))
+            } else {
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(mapOf("error" to (e.message ?: "사용권 획득 처리 중 오류가 발생했습니다.")))
+            }
+        } catch (e: Exception) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(mapOf("error" to "사용권 획득 처리 중 예상치 못한 오류가 발생했습니다."))
+        }
+    }
+
 } 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackController.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackController.kt
@@ -2,6 +2,7 @@ package kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack
 
 import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.dto.*
 import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.usageright.VoicepackUsageRightDto
+import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.usageright.VoicepackUsageRightBriefDto
 import org.springframework.http.ResponseEntity
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
@@ -212,6 +213,31 @@ class VoicepackController(
         } catch (e: Exception) {
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(mapOf("error" to "사용권 획득 처리 중 예상치 못한 오류가 발생했습니다."))
         }
+    }
+
+
+    // 사용자가 사용권을 보유한 보이스팩 목록 조회
+    @Operation(
+        summary = "사용자가 사용권을 보유한 보이스팩 목록 조회",
+        description = "사용자가 사용권을 보유한 보이스팩 목록을 조회합니다.",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "조회 성공",
+                content = [Content(schema = Schema(implementation = List::class))]
+            ),
+            ApiResponse(
+                responseCode = "500",   
+                description = "서버 오류"
+            )
+        ]
+    )
+    @GetMapping("/user-voicepacks")
+    fun getUserVoicepacks(
+        @Parameter(description = "사용자 ID") @RequestParam userId: Long
+    ): ResponseEntity<List<VoicepackUsageRightBriefDto>> {
+        val voicepacks = voicepackService.getVoicepacksByUserId(userId)
+        return ResponseEntity.ok(voicepacks)
     }
 
 } 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackService.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackService.kt
@@ -18,9 +18,12 @@ import kr.ac.kookmin.cs.capstone.voicepack_platform.notification.NotificationSer
 import kr.ac.kookmin.cs.capstone.voicepack_platform.user.UserRepository
 import kr.ac.kookmin.cs.capstone.voicepack_platform.user.User
 import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.dto.*
+import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.usageright.VoicepackUsageRightDto
+import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.usageright.VoicepackUsageRight
 import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.request.VoicepackRequestStatus
 import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.request.VoicepackRequest
 import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.request.VoicepackRequestRepository
+import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.usageright.VoicepackUsageRightRepository
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
@@ -33,8 +36,10 @@ import kr.ac.kookmin.cs.capstone.voicepack_platform.common.util.S3PresignedUrlGe
 class VoicepackService(
         private val voicepackRepository: VoicepackRepository,
         private val voicepackRequestRepository: VoicepackRequestRepository,
+        private val voicepackUsageRightRepository: VoicepackUsageRightRepository,
         private val userRepository: UserRepository,
         private val notificationService: NotificationService,
+        // private val creditService: CreditService,
         @Value("\${ai.model.service.voicepack_creation}") private val voicepackCreationEndpoint: String,
         @Value("\${ai.model.service.voicepack_synthesis}") private val voicepackSynthesisEndpoint: String,
         private val s3PresignedUrlGenerator: S3PresignedUrlGenerator
@@ -304,4 +309,42 @@ class VoicepackService(
         val s3ObjectKey = "speakers/${voicepack.name}/sample_test.wav"
         return s3PresignedUrlGenerator.generatePresignedUrl(s3ObjectKey)
     }
+
+    /**
+     * 보이스팩 사용권 획득 처리 (구매 또는 제작자 획득)
+     */
+    @Transactional
+    fun grantUsageRight(userId: Long, voicepackId: Long): VoicepackUsageRightDto {
+        logger.info("보이스팩 사용권 획득 요청: userId={}, voicepackId={}", userId, voicepackId)
+
+        val user = findUser(userId)
+        val voicepack = findVoicepack(voicepackId)
+
+        // 1. 이미 사용권을 가지고 있는지 확인
+        if (voicepackUsageRightRepository.existsByUserIdAndVoicepackId(userId, voicepackId)) {
+            logger.warn("이미 사용권을 가지고 있는 보이스팩입니다: userId={}, voicepackId={}", userId, voicepackId)
+            throw IllegalStateException("이미 사용권을 가지고 있는 보이스팩입니다.")
+        }
+
+        // 2. (선택 사항) 가격 확인 및 크레딧 차감 (제작자가 아닌 경우에만)
+        // if (voicepack.author.id != userId) {
+        //     // TODO: 보이스팩 가격 확인 및 크레딧 차감 로직
+        //     /*
+        //     val voicepackPrice = voicepack.price ?: 0
+        //     if (voicepackPrice > 0) { ... }
+        //     */
+        // }
+
+        // 3. 사용권 정보 생성 및 저장
+        val usageRight = VoicepackUsageRight(
+            user = user,
+            voicepack = voicepack
+        )
+        val savedUsageRight = voicepackUsageRightRepository.save(usageRight)
+        logger.info("보이스팩 사용권 저장 성공: usageRightId={}, userId={}, voicepackId={}", savedUsageRight.id, userId, voicepackId)
+
+        // 4. 결과 반환
+        return VoicepackUsageRightDto.fromEntity(savedUsageRight)
+    }
+
 }

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackService.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackService.kt
@@ -24,6 +24,7 @@ import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.request.VoicepackR
 import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.request.VoicepackRequest
 import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.request.VoicepackRequestRepository
 import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.usageright.VoicepackUsageRightRepository
+import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.usageright.VoicepackUsageRightBriefDto
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
@@ -346,5 +347,14 @@ class VoicepackService(
         // 4. 결과 반환
         return VoicepackUsageRightDto.fromEntity(savedUsageRight)
     }
+
+
+    /**
+     * 사용자가 보유한 보이스팩 목록 조회
+     */
+    fun getVoicepacksByUserId(userId: Long): List<VoicepackUsageRightBriefDto> {
+        logger.info("사용자의 보이스팩 목록 조회: userId={}", userId)
+        return voicepackUsageRightRepository.findVoicepackDtosByUserId(userId)
+    } 
 
 }

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/usageright/VoicepackUsageRight.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/usageright/VoicepackUsageRight.kt
@@ -1,0 +1,27 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.usageright
+
+import jakarta.persistence.*
+import kr.ac.kookmin.cs.capstone.voicepack_platform.user.User
+import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.Voicepack
+import java.time.OffsetDateTime
+
+@Entity
+@Table(name = "voicepack_usage_rights", uniqueConstraints = [
+    UniqueConstraint(columnNames = ["user_id", "voicepack_id"])
+])
+data class VoicepackUsageRight(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "voicepack_id", nullable = false)
+    val voicepack: Voicepack,
+
+    @Column(name = "granted_at", nullable = false)
+    val grantedAt: OffsetDateTime = OffsetDateTime.now()
+) 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/usageright/VoicepackUsageRightDto.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/usageright/VoicepackUsageRightDto.kt
@@ -23,3 +23,10 @@ data class VoicepackUsageRightDto(
         }
     }
 } 
+
+// voicepackId와 voicepackName만 반환하는 DTO
+@Serializable
+data class VoicepackUsageRightBriefDto(
+    val voicepackId: Long,
+    val voicepackName: String
+)

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/usageright/VoicepackUsageRightDto.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/usageright/VoicepackUsageRightDto.kt
@@ -1,0 +1,25 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.usageright
+
+import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.usageright.VoicepackUsageRight
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class VoicepackUsageRightDto(
+    val id: Long,
+    val userId: Long,
+    val voicepackId: Long,
+    val voicepackName: String,
+    val grantedAt: String
+) {
+    companion object {
+        fun fromEntity(usageRight: VoicepackUsageRight): VoicepackUsageRightDto {
+            return VoicepackUsageRightDto(
+                id = usageRight.id,
+                userId = usageRight.user.id,
+                voicepackId = usageRight.voicepack.id,
+                voicepackName = usageRight.voicepack.name,
+                grantedAt = usageRight.grantedAt.toString()
+            )
+        }
+    }
+} 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/usageright/VoicepackUsageRightRepository.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/usageright/VoicepackUsageRightRepository.kt
@@ -2,6 +2,7 @@ package kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.usageright
 
 import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.usageright.VoicepackUsageRight
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -9,8 +10,15 @@ interface VoicepackUsageRightRepository : JpaRepository<VoicepackUsageRight, Lon
     // 특정 사용자가 특정 보이스팩 사용권을 가지고 있는지 확인
     fun existsByUserIdAndVoicepackId(userId: Long, voicepackId: Long): Boolean
 
-    // 특정 사용자가 보유한 모든 보이스팩 ID 목록 조회
-    fun findVoicepackIdsByUserId(userId: Long): List<Long>
+    @Query("""
+        SELECT new kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.usageright.VoicepackUsageRightBriefDto(
+            v.voicepack.id,
+            v.voicepack.name
+        )
+        FROM VoicepackUsageRight v
+        WHERE v.user.id = :userId
+    """)
+    fun findVoicepackDtosByUserId(userId: Long): List<VoicepackUsageRightBriefDto>
 
     // 특정 사용자가 보유한 모든 사용권 정보 조회 (페이지네이션 가능)
     // fun findByUserId(userId: Long, pageable: Pageable): Page<VoicepackUsageRight>

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/usageright/VoicepackUsageRightRepository.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/usageright/VoicepackUsageRightRepository.kt
@@ -1,0 +1,17 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.usageright
+
+import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.usageright.VoicepackUsageRight
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface VoicepackUsageRightRepository : JpaRepository<VoicepackUsageRight, Long> {
+    // 특정 사용자가 특정 보이스팩 사용권을 가지고 있는지 확인
+    fun existsByUserIdAndVoicepackId(userId: Long, voicepackId: Long): Boolean
+
+    // 특정 사용자가 보유한 모든 보이스팩 ID 목록 조회
+    fun findVoicepackIdsByUserId(userId: Long): List<Long>
+
+    // 특정 사용자가 보유한 모든 사용권 정보 조회 (페이지네이션 가능)
+    // fun findByUserId(userId: Long, pageable: Pageable): Page<VoicepackUsageRight>
+} 


### PR DESCRIPTION
# 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈를 추가해주세요. (예: #123) 이슈 번호 앞에 Closes 작성하면 PR 머지할 때 자동으로 이슈가 닫힙니다.-->

Issue: #45

---

# ✨ 작업 사항
<!-- 이 PR에서 작업한 내용을 자유롭게 정리해주세요. -->

## PR 본문 작성 (feat: 보이스팩 사용권 획득 API 및 관련 데이터 모델 추가)

### 작업 내용

1.  **사용권 모델 추가 (`VoicepackUsageRight.kt`)**
    *   사용자와 보이스팩 간의 사용권 관계를 나타내는 `VoicepackUsageRight` 엔티티를 새로 정의했습니다.
    *   `user`, `voicepack`, `grantedAt` (획득 시점) 필드를 포함합니다.
    *   사용자-보이스팩 조합의 중복 생성을 방지하기 위해 unique constraint를 추가했습니다.

2.  **사용권 레포지토리 추가 (`VoicepackUsageRightRepository.kt`)**
    *   `VoicepackUsageRight` 엔티티에 대한 CRUD 및 조회 작업을 위한 `JpaRepository`를 구현했습니다.
    *   특정 사용자의 특정 보이스팩 사용권 존재 여부 확인 (`existsByUserIdAndVoicepackId`) 및 사용자별 보유 보이스팩 ID 목록 조회 (`findVoicepackIdsByUserId`) 메서드를 정의했습니다.

3.  **사용권 DTO 추가 (`VoicepackUsageRightDto.kt`)**
    *   API 응답 등에서 사용될 `VoicepackUsageRightDto` 데이터 클래스를 정의했습니다.
    *   엔티티를 DTO로 변환하는 `fromEntity` 팩토리 메서드를 포함합니다.

4.  **서비스 로직 추가 (`VoicepackService.kt`)**
    *   `VoicepackUsageRightRepository` 의존성을 주입했습니다.
    *   `grantUsageRight(userId, voicepackId)` 메서드를 새로 추가했습니다.
        *   요청된 사용자와 보이스팩 정보를 조회합니다.
        *   이미 사용권을 보유하고 있는지 확인하고, 있다면 예외를 발생시킵니다.
        *   (주석 처리됨) 향후 제작자가 아닌 경우 가격 확인 및 크레딧 차감 로직을 추가할 수 있습니다 - #43 완료 후 추가 개발할 부분입니다.
        *   사용권이 없다면 `VoicepackUsageRight` 엔티티를 생성하고 저장합니다. (사용권 등록)
        *   결과를 `VoicepackUsageRightDto`로 변환하여 반환합니다.

5.  **API 엔드포인트 추가 (`VoicepackController.kt`)**
   *   **`POST /api/voicepack/usage-right` 엔드포인트를 새로 추가했습니다. (수정됨)**
       *   `userId`와 `voicepackId`를 파라미터로 받아 `voicepackService.grantUsageRight`를 호출합니다.
       *   성공 시 200 (OK)과 함께 사용권 정보를 반환합니다.
       *   발생 가능한 예외(사용자/보이스팩 없음, 이미 보유, 크레딧 부족 등)에 따라 적절한 HTTP 상태 코드(400, 409, 402, 500)와 오류 메시지를 반환하도록 처리했습니다.
       *   Swagger 문서화를 추가하여 API 명세를 명확히 했습니다.
   * **`GET /api/voicepack/usage-right` 엔드포인트를 새로 추가했습니다. (추가됨)**
       * `userId`를 파라미터로 받아 해당 사용자가 사용권을 보유한 모든 보이스팩의 `id`와 `name`을 리스트로 반환합니다.


### 기대 효과

-   사용자는 API를 통해 특정 보이스팩의 사용권을 획득할 수 있습니다.
-   제작자는 구매 요청 시 크레딧 소모 없이 자신이 만든 보이스팩의 사용권을 가집니다.
     -  해당 내용은 향후 자동으로 소유권을 얻도록 수정할 계획입니다.
-   시스템은 사용자별 보이스팩 사용권 보유 현황을 관리하고 중복 획득을 방지합니다.

---

# 📸 스크린샷 (선택)
<!-- 변경된 UI나 버그 수정 전후 비교 화면이 있다면 추가해주세요. -->
<!-- 이미지는 이슈 제출 후 드래그 앤 드롭으로 업로드할 수 있습니다. -->

---

# 🔗 참고 자료 (선택)
<!-- 관련 문서, 디자인 시안, API 문서 등이 있다면 추가해주세요. -->
- 예: [Figma 디자인](https://www.figma.com/), [API 문서](https://api.docs.example.com/)

---

# 🙋🏻 리뷰 요구사항 (선택)
<!-- 코드 리뷰 요청이 필요한 부분을 구체적으로 작성해주세요. -->
- 이 PR의 주요 변경 사항이 적절한 방향인지 검토 부탁드립니다.
- 사용한 디자인 패턴이 적절한지 확인해 주세요.
- 코드 스타일 및 네이밍이 일관적인지 봐주세요.

---

# 🚀 PR 체크리스트
- [x] 내 코드가 정상적으로 동작하는지 테스트했나요?
- [x] 이 PR이 관련된 이슈와 연결되었나요?
- [x] 팀원들과 논의가 필요한 부분이 있나요?