### PR TITLE
feat: 마이페이지 기능 구현 (대시보드, 보이스팩/수입/크레딧 관리)

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -42,3 +42,4 @@ out/
 ### resources ###
 application.properties
 application.yaml
+application-local.yaml

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/controller/CreditController.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/controller/CreditController.kt
@@ -1,0 +1,243 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.credit.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.dto.*
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.service.CreditService
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Page
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/credits")
+@Tag(name = "크레딧", description = "사용자 크레딧 관리 API")
+class CreditController(
+    private val creditService: CreditService
+) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+    
+    @Operation(
+        summary = "크레딧 잔액 조회",
+        description = "사용자의 현재 크레딧 잔액을 조회합니다.",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "성공",
+                content = [Content(schema = Schema(implementation = CreditBalanceDto::class))]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "사용자를 찾을 수 없음"
+            )
+        ]
+    )
+    @GetMapping("/balance/{userId}")
+    fun getBalance(
+        @Parameter(description = "사용자 ID") 
+        @PathVariable userId: Long
+    ): ResponseEntity<CreditBalanceDto> {
+        try {
+            val balance = creditService.getUserBalance(userId)
+            return ResponseEntity.ok(balance)
+        } catch (e: IllegalArgumentException) {
+            logger.error("잔액 조회 실패: {}", e.message)
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build()
+        } catch (e: Exception) {
+            logger.error("잔액 조회 중 오류 발생: {}", e.message, e)
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()
+        }
+    }
+    
+    @Operation(
+        summary = "크레딧 충전",
+        description = "사용자의 크레딧을 충전합니다.",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "충전 성공",
+                content = [Content(schema = Schema(implementation = TransactionResultDto::class))]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청"
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "사용자를 찾을 수 없음"
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "서버 오류"
+            )
+        ]
+    )
+    @PostMapping("/charge")
+    fun chargeCredits(
+        @RequestBody request: ChargeCreditsRequest
+    ): ResponseEntity<TransactionResultDto> {
+        try {
+            val result = creditService.chargeCredits(request)
+            return ResponseEntity.ok(result)
+        } catch (e: IllegalArgumentException) {
+            logger.error("충전 요청 실패: {}", e.message)
+            return ResponseEntity.badRequest().build()
+        } catch (e: Exception) {
+            logger.error("충전 중 오류 발생: {}", e.message, e)
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()
+        }
+    }
+    
+    @Operation(
+        summary = "크레딧 사용",
+        description = "특정 목적으로 사용자의 크레딧을 사용합니다.",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "사용 성공",
+                content = [Content(schema = Schema(implementation = TransactionResultDto::class))]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청"
+            ),
+            ApiResponse(
+                responseCode = "402",
+                description = "크레딧 부족"
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "사용자를 찾을 수 없음"
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "서버 오류"
+            )
+        ]
+    )
+    @PostMapping("/use")
+    fun useCredits(
+        @RequestBody request: UseCreditsRequest
+    ): ResponseEntity<TransactionResultDto> {
+        try {
+            val result = creditService.useCredits(request)
+            return ResponseEntity.ok(result)
+        } catch (e: IllegalArgumentException) {
+            logger.error("사용 요청 실패: {}", e.message)
+            return ResponseEntity.badRequest().build()
+        } catch (e: IllegalStateException) {
+            // 크레딧 부족
+            logger.error("크레딧 부족: {}", e.message)
+            return ResponseEntity.status(HttpStatus.PAYMENT_REQUIRED).build()
+        } catch (e: Exception) {
+            logger.error("크레딧 사용 중 오류 발생: {}", e.message, e)
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()
+        }
+    }
+    
+    @Operation(
+        summary = "크레딧 환전",
+        description = "사용자의 크레딧을 현금으로 환전합니다.",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "환전 요청 성공",
+                content = [Content(schema = Schema(implementation = TransactionResultDto::class))]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청"
+            ),
+            ApiResponse(
+                responseCode = "402",
+                description = "크레딧 부족"
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "사용자를 찾을 수 없음"
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "서버 오류"
+            )
+        ]
+    )
+    @PostMapping("/exchange")
+    fun exchangeCredits(
+        @RequestBody request: ExchangeCreditsRequest
+    ): ResponseEntity<TransactionResultDto> {
+        try {
+            val result = creditService.exchangeCredits(request)
+            return ResponseEntity.ok(result)
+        } catch (e: IllegalArgumentException) {
+            logger.error("환전 요청 실패: {}", e.message)
+            return ResponseEntity.badRequest().build()
+        } catch (e: IllegalStateException) {
+            // 크레딧 부족
+            logger.error("크레딧 부족: {}", e.message)
+            return ResponseEntity.status(HttpStatus.PAYMENT_REQUIRED).build()
+        } catch (e: Exception) {
+            logger.error("크레딧 환전 중 오류 발생: {}", e.message, e)
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()
+        }
+    }
+    
+    @Operation(
+        summary = "거래 내역 조회",
+        description = "사용자의 크레딧 거래 내역을 조회합니다.",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "조회 성공"
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청"
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "사용자를 찾을 수 없음"
+            ),
+            ApiResponse(
+                responseCode = "500",
+                description = "서버 오류"
+            )
+        ]
+    )
+    @GetMapping("/transactions")
+    fun getTransactions(
+        @Parameter(description = "사용자 ID") @RequestParam userId: Long,
+        @Parameter(description = "거래 유형 (CHARGE, PURCHASE, REFUND, SYSTEM)") @RequestParam(required = false) type: String?,
+        @Parameter(description = "거래 상태 (PENDING, COMPLETED, FAILED)") @RequestParam(required = false) status: String?,
+        @Parameter(description = "시작 날짜 (ISO-8601 형식)") @RequestParam(required = false) startDate: String?,
+        @Parameter(description = "종료 날짜 (ISO-8601 형식)") @RequestParam(required = false) endDate: String?,
+        @Parameter(description = "페이지 번호 (0부터 시작)") @RequestParam(defaultValue = "0") page: Int,
+        @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "20") size: Int
+    ): ResponseEntity<Page<CreditTransactionDto>> {
+        try {
+            val request = GetTransactionsRequest(
+                userId = userId,
+                type = type,
+                status = status,
+                startDate = startDate,
+                endDate = endDate,
+                page = page,
+                size = size
+            )
+            
+            val transactions = creditService.getTransactionHistory(request)
+            return ResponseEntity.ok(transactions)
+        } catch (e: IllegalArgumentException) {
+            logger.error("거래 내역 조회 실패: {}", e.message)
+            return ResponseEntity.badRequest().build()
+        } catch (e: Exception) {
+            logger.error("거래 내역 조회 중 오류 발생: {}", e.message, e)
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()
+        }
+    }
+} 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/controller/CreditController.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/controller/CreditController.kt
@@ -249,7 +249,7 @@ class CreditController(
             ApiResponse(responseCode = "500", description = "서버 오류")
         ]
     )
-    @GetMapping("/exchange-requests/{userId}")
+    @GetMapping("/exchange-request/{userId}")
     fun getCreditExchangeRequests(
         @Parameter(description = "사용자 ID") @PathVariable userId: Long,
         @Parameter(required = false, description = "페이지 정보", example = """

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/dto/CreditChargeRequestDto.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/dto/CreditChargeRequestDto.kt
@@ -1,0 +1,10 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.credit.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class CreditChargeRequestDto(
+    @Schema(description = "충전할 원화 금액", example = "10000")
+    val amount: Int, // 원화 기준
+    @Schema(description = "결제 수단", example = "카카오페이")
+    val method: String
+) 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/dto/CreditDto.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/dto/CreditDto.kt
@@ -1,0 +1,104 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.credit.dto
+
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.Credit
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.CreditTransaction
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.ReferenceType
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.TransactionStatus
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.TransactionType
+import java.time.OffsetDateTime
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CreditBalanceDto(
+    val userId: Long,
+    val balance: Int,
+    val updatedAt: String
+) {
+    companion object {
+        fun fromEntity(credit: Credit): CreditBalanceDto {
+            return CreditBalanceDto(
+                userId = credit.user.id,
+                balance = credit.balance,
+                updatedAt = credit.updatedAt.toString()
+            )
+        }
+    }
+}
+
+@Serializable
+data class CreditTransactionDto(
+    val id: Long,
+    val userId: Long,
+    val amount: Int,
+    val type: String,
+    val referenceId: Long? = null,
+    val referenceType: String? = null,
+    val description: String? = null,
+    val status: String,
+    val balanceBefore: Int,
+    val balanceAfter: Int? = null,
+    val createdAt: String
+) {
+    companion object {
+        fun fromEntity(transaction: CreditTransaction): CreditTransactionDto {
+            return CreditTransactionDto(
+                id = transaction.id,
+                userId = transaction.user.id,
+                amount = transaction.amount,
+                type = transaction.type.name,
+                referenceId = transaction.referenceId,
+                referenceType = transaction.referenceType?.name,
+                description = transaction.description,
+                status = transaction.status.name,
+                balanceBefore = transaction.balanceBefore,
+                balanceAfter = transaction.balanceAfter,
+                createdAt = transaction.createdAt.toString()
+            )
+        }
+    }
+}
+
+@Serializable
+data class ChargeCreditsRequest(
+    val userId: Long,
+    val amount: Int,
+    val paymentMethod: String? = null,
+    val paymentReference: String? = null
+)
+
+@Serializable
+data class UseCreditsRequest(
+    val userId: Long,
+    val amount: Int,
+    val referenceId: Long? = null,
+    val referenceType: ReferenceType? = null,
+    val description: String? = null
+)
+
+@Serializable
+data class ExchangeCreditsRequest(
+    val userId: Long,
+    val amount: Int,
+    val bankName: String? = null,
+    val accountNumber: String? = null,
+    val accountHolder: String? = null
+)
+
+@Serializable
+data class TransactionResultDto(
+    val transactionId: Long,
+    val status: String,
+    val newBalance: Int? = null,
+    val message: String? = null
+)
+
+@Serializable
+data class GetTransactionsRequest(
+    val userId: Long,
+    val type: String? = null,
+    val status: String? = null,
+    val startDate: String? = null,
+    val endDate: String? = null,
+    val page: Int = 0,
+    val size: Int = 20
+) 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/dto/CreditDto.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/dto/CreditDto.kt
@@ -63,12 +63,12 @@ data class ChargeCreditsRequest(
     val userId: Long,
     val amount: Int,
     val paymentMethod: String? = null,
-    val paymentReference: String? = null
+    val paymentReference: Long? = null
 )
 
 @Serializable
 data class UseCreditsRequest(
-    val userId: Long,
+    // val userId: Long,
     val amount: Int,
     val referenceId: Long? = null,
     val referenceType: ReferenceType? = null,

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/dto/CreditExchangeRequestDto.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/dto/CreditExchangeRequestDto.kt
@@ -1,0 +1,28 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.credit.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.CreditExchangeRequest
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.ExchangeStatus
+import java.time.OffsetDateTime
+
+data class CreditExchangeRequestDto(
+    @Schema(description = "환전 신청 ID", example = "1")
+    val id: Long,
+    @Schema(description = "신청 날짜")
+    val date: OffsetDateTime,
+    @Schema(description = "신청 금액 (원화)", example = "50000")
+    val amountWon: Int,
+    @Schema(description = "처리 상태", example = "PENDING")
+    val status: ExchangeStatus
+) {
+    companion object {
+        fun fromEntity(entity: CreditExchangeRequest): CreditExchangeRequestDto {
+            return CreditExchangeRequestDto(
+                id = entity.id,
+                date = entity.requestDate,
+                amountWon = entity.wonAmount,
+                status = entity.status
+            )
+        }
+    }
+} 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/dto/CreditExchangeRequestRequestDto.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/dto/CreditExchangeRequestRequestDto.kt
@@ -1,0 +1,16 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.credit.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class CreditExchangeRequestRequestDto(
+    @Schema(description = "환전 신청할 크레딧 양", example = "320")
+    val credit: Int,
+
+    // TODO: 환전 계좌 정보 필드 추가 필요 (bankName, accountNumber, accountHolder)
+    @Schema(description = "은행 이름", example = "국민은행")
+    val bankName: String,
+    @Schema(description = "계좌 번호", example = "123-456-789")
+    val accountNumber: String,
+    @Schema(description = "예금주명", example = "홍길동")
+    val accountHolder: String
+) 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/dto/CreditExchangeResponseDto.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/dto/CreditExchangeResponseDto.kt
@@ -1,0 +1,10 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.credit.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class CreditExchangeResponseDto(
+    @Schema(description = "처리 결과 메시지", example = "환전 신청이 완료되었습니다.")
+    val message: String,
+    @Schema(description = "환전될 예상 원화 금액", example = "32000")
+    val won: Int
+) 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/dto/CreditHistoryDto.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/dto/CreditHistoryDto.kt
@@ -1,0 +1,34 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.credit.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.OffsetDateTime
+
+// 충전 내역 DTO
+data class ChargeDto(
+    @Schema(description = "날짜")
+    val date: OffsetDateTime,
+    @Schema(description = "원화 금액", example = "5000")
+    val amountWon: Int?, // 원화 금액은 Transaction description 파싱 필요? 또는 별도 저장?
+    @Schema(description = "충전된 크레딧", example = "50")
+    val amountCredit: Int,
+    @Schema(description = "결제 수단", example = "카카오페이")
+    val method: String?
+)
+
+// 사용 내역 DTO
+data class UsageDto(
+    @Schema(description = "날짜")
+    val date: OffsetDateTime,
+    @Schema(description = "사용처", example = "감성 보이스 구매")
+    val usage: String?,
+    @Schema(description = "사용한 크레딧", example = "100")
+    val amountCredit: Int
+)
+
+// 크레딧 내역 통합 DTO
+data class CreditHistoryDto(
+    @Schema(description = "충전 내역 리스트")
+    val charges: List<ChargeDto>,
+    @Schema(description = "사용 내역 리스트")
+    val usages: List<UsageDto>
+) 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/model/Credit.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/model/Credit.kt
@@ -1,0 +1,27 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model
+
+import jakarta.persistence.*
+import kr.ac.kookmin.cs.capstone.voicepack_platform.user.User
+import java.time.OffsetDateTime
+
+@Entity
+@Table(name = "user_credits")
+data class Credit(
+    @Id
+    @Column(name = "credit_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    val user: User,
+    
+    @Column(name = "balance", nullable = false)
+    var balance: Int = 0,
+    
+    @Column(name = "created_at", nullable = false)
+    val createdAt: OffsetDateTime = OffsetDateTime.now(),
+    
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: OffsetDateTime = OffsetDateTime.now()
+) 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/model/CreditExchangeRequest.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/model/CreditExchangeRequest.kt
@@ -1,0 +1,51 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model
+
+import jakarta.persistence.*
+import kr.ac.kookmin.cs.capstone.voicepack_platform.user.User
+import java.time.OffsetDateTime
+
+@Entity
+@Table(name = "credit_exchange_requests")
+data class CreditExchangeRequest(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
+
+    @Column(name = "credit_amount", nullable = false)
+    val creditAmount: Int, // 신청한 크레딧 양
+
+    @Column(name = "won_amount", nullable = false)
+    val wonAmount: Int, // 환전될 원화 금액 (신청 시점 기준)
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    var status: ExchangeStatus = ExchangeStatus.PENDING, // 환전 상태
+
+    // TODO: 환전 신청 시 필요한 계좌 정보 등 추가 필드 고려
+    // 예: bankName, accountNumber, accountHolder
+    @Column(name = "bank_name", nullable = false)
+    val bankName: String,
+    
+    @Column(name = "account_number", nullable = false)
+    val accountNumber: String,
+    
+    @Column(name = "account_holder", nullable = false)
+    val accountHolder: String,
+
+    @Column(name = "request_date", nullable = false)
+    val requestDate: OffsetDateTime = OffsetDateTime.now(), // 신청 시점
+
+    @Column(name = "completion_date")
+    var completionDate: OffsetDateTime? = null // 처리 완료 시점
+)
+
+enum class ExchangeStatus {
+    PENDING,    // 처리 대기 중
+    PROCESSING, // 처리 중
+    COMPLETED,  // 처리 완료 (입금 완료)
+    REJECTED    // 처리 거절
+} 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/model/CreditTransaction.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/model/CreditTransaction.kt
@@ -55,7 +55,8 @@ enum class TransactionType {
     PURCHASE,    // 보이스팩 구매 등에 사용
     REFUND,      // 환불
     EXCHANGE,    // 크레딧을 현금으로 환전
-    SYSTEM       // 시스템 조정 (관리자 조정 등)
+    SYSTEM,      // 시스템 조정 (관리자 조정 등)
+    SALE_INCOME  // 판매 수익 (충전과 유사)
 }
 
 enum class TransactionStatus {
@@ -65,11 +66,8 @@ enum class TransactionStatus {
 }
 
 enum class ReferenceType {
-    VOICEPACK,  // 보이스팩 관련
-    ORDER,      // 주문 관련
-    PAYMENT,    // 결제 관련
-    BANK_ACCOUNT, // 계좌 정보 관련
-    PROMOTION,  // 프로모션 관련
-    USER,       // 사용자 관련
-    SYSTEM      // 시스템 관련
+    PAYMENT,       // 결제 (충전)
+    VOICEPACK,     // 보이스팩 구매
+    CREDIT_EXCHANGE // 크레딧 환전
+    // 필요에 따라 추가 (예: TTS_SYNTHESIS)
 } 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/model/CreditTransaction.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/model/CreditTransaction.kt
@@ -1,0 +1,75 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model
+
+import jakarta.persistence.*
+import kr.ac.kookmin.cs.capstone.voicepack_platform.user.User
+import java.time.OffsetDateTime
+
+@Entity
+@Table(name = "credit_transactions")
+data class CreditTransaction(
+    @Id
+    @Column(name = "transaction_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
+    
+    @Column(name = "amount", nullable = false)
+    val amount: Int,
+    
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    val type: TransactionType,
+    
+    @Column(name = "reference_id", nullable = true)
+    val referenceId: Long? = null,
+    
+    @Column(name = "reference_type", nullable = true)
+    @Enumerated(EnumType.STRING)
+    val referenceType: ReferenceType? = null,
+    
+    @Column(name = "description", nullable = true)
+    val description: String? = null,
+    
+    @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    var status: TransactionStatus = TransactionStatus.PENDING,
+    
+    @Column(name = "balance_before", nullable = false)
+    val balanceBefore: Int,
+    
+    @Column(name = "balance_after", nullable = true)
+    var balanceAfter: Int? = null,
+    
+    @Column(name = "created_at", nullable = false)
+    val createdAt: OffsetDateTime = OffsetDateTime.now(),
+    
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: OffsetDateTime = OffsetDateTime.now()
+)
+
+enum class TransactionType {
+    CHARGE,      // 크레딧 충전
+    PURCHASE,    // 보이스팩 구매 등에 사용
+    REFUND,      // 환불
+    EXCHANGE,    // 크레딧을 현금으로 환전
+    SYSTEM       // 시스템 조정 (관리자 조정 등)
+}
+
+enum class TransactionStatus {
+    PENDING,    // 진행 중
+    COMPLETED,  // 완료됨
+    FAILED      // 실패함
+}
+
+enum class ReferenceType {
+    VOICEPACK,  // 보이스팩 관련
+    ORDER,      // 주문 관련
+    PAYMENT,    // 결제 관련
+    BANK_ACCOUNT, // 계좌 정보 관련
+    PROMOTION,  // 프로모션 관련
+    USER,       // 사용자 관련
+    SYSTEM      // 시스템 관련
+} 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/repository/CreditExchangeRequestRepository.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/repository/CreditExchangeRequestRepository.kt
@@ -1,0 +1,14 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.credit.repository
+
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.CreditExchangeRequest
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface CreditExchangeRequestRepository : JpaRepository<CreditExchangeRequest, Long> {
+
+    // 사용자 ID로 환전 신청 내역 조회 (페이징 및 최신순 정렬)
+    fun findByUserIdOrderByRequestDateDesc(userId: Long, pageable: Pageable): Page<CreditExchangeRequest>
+} 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/repository/CreditRepository.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/repository/CreditRepository.kt
@@ -1,0 +1,11 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.credit.repository
+
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.Credit
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.util.Optional
+
+@Repository
+interface CreditRepository : JpaRepository<Credit, Long> {
+    fun findByUserId(userId: Long): Optional<Credit>
+} 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/repository/CreditRepository.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/repository/CreditRepository.kt
@@ -7,5 +7,5 @@ import java.util.Optional
 
 @Repository
 interface CreditRepository : JpaRepository<Credit, Long> {
-    fun findByUserId(userId: Long): Optional<Credit>
+    fun findByUserId(userId: Long): Credit?
 } 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/repository/CreditTransactionRepository.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/repository/CreditTransactionRepository.kt
@@ -38,4 +38,7 @@ interface CreditTransactionRepository : JpaRepository<CreditTransaction, Long> {
         referenceType: ReferenceType,
         pageable: Pageable
     ): Page<CreditTransaction>
+
+    // 사용자 ID와 상태로 조회 (최신순 정렬)
+    fun findByUserIdAndStatusOrderByCreatedAtDesc(userId: Long, status: TransactionStatus): List<CreditTransaction>
 } 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/repository/CreditTransactionRepository.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/repository/CreditTransactionRepository.kt
@@ -1,0 +1,41 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.credit.repository
+
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.CreditTransaction
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.ReferenceType
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.TransactionStatus
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.TransactionType
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import java.time.OffsetDateTime
+
+@Repository
+interface CreditTransactionRepository : JpaRepository<CreditTransaction, Long> {
+    fun findByUserId(userId: Long, pageable: Pageable): Page<CreditTransaction>
+    
+    fun findByUserIdAndCreatedAtBetween(
+        userId: Long, 
+        startDate: OffsetDateTime, 
+        endDate: OffsetDateTime,
+        pageable: Pageable
+    ): Page<CreditTransaction>
+    
+    fun findByUserIdAndType(
+        userId: Long, 
+        type: TransactionType,
+        pageable: Pageable
+    ): Page<CreditTransaction>
+    
+    fun findByUserIdAndStatus(
+        userId: Long, 
+        status: TransactionStatus,
+        pageable: Pageable
+    ): Page<CreditTransaction>
+    
+    fun findByReferenceIdAndReferenceType(
+        referenceId: Long,
+        referenceType: ReferenceType,
+        pageable: Pageable
+    ): Page<CreditTransaction>
+} 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/service/CreditService.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/service/CreditService.kt
@@ -1,0 +1,348 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.credit.service
+
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.dto.*
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.Credit
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.CreditTransaction
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.ReferenceType
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.TransactionStatus
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.TransactionType
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.repository.CreditRepository
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.repository.CreditTransactionRepository
+import kr.ac.kookmin.cs.capstone.voicepack_platform.user.User
+import kr.ac.kookmin.cs.capstone.voicepack_platform.user.UserRepository
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+
+@Service
+class CreditService(
+    private val creditRepository: CreditRepository,
+    private val creditTransactionRepository: CreditTransactionRepository,
+    private val userRepository: UserRepository
+) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+    
+    /**
+     * 사용자의 크레딧 잔액을 조회합니다.
+     */
+    @Transactional(readOnly = true)
+    fun getUserBalance(userId: Long): CreditBalanceDto {
+        logger.info("크레딧 잔액 조회: userId={}", userId)
+        
+        val credit = findOrCreateUserCredit(userId)
+        return CreditBalanceDto.fromEntity(credit)
+    }
+    
+    /**
+     * 크레딧을 충전합니다.
+     */
+    @Transactional
+    fun chargeCredits(request: ChargeCreditsRequest): TransactionResultDto {
+        logger.info("크레딧 충전 요청: {}", request)
+        
+        if (request.amount <= 0) {
+            throw IllegalArgumentException("충전 금액은 양수여야 합니다")
+        }
+        
+        val user = findUser(request.userId)
+        val credit = findOrCreateUserCredit(user.id)
+        val balanceBefore = credit.balance
+        
+        // 트랜잭션 기록 생성
+        val transaction = CreditTransaction(
+            user = user,
+            amount = request.amount,
+            type = TransactionType.CHARGE,
+            description = "크레딧 충전: ${request.paymentMethod ?: "일반"}",
+            status = TransactionStatus.PENDING,
+            balanceBefore = balanceBefore
+        )
+        creditTransactionRepository.save(transaction)
+        
+        try {
+            // 실제 충전 로직 (실제 결제 시스템 연동은 여기서 구현)
+            
+            // 크레딧 잔액 업데이트
+            val time = OffsetDateTime.now()
+
+            credit.balance += request.amount
+            credit.updatedAt = time
+            creditRepository.save(credit)
+            
+            // 트랜잭션 상태 업데이트
+            transaction.status = TransactionStatus.COMPLETED
+            transaction.balanceAfter = credit.balance
+            transaction.updatedAt = time
+            creditTransactionRepository.save(transaction)
+            
+            logger.info("크레딧 충전 성공: userId={}, amount={}, newBalance={}", 
+                user.id, request.amount, credit.balance)
+            
+            return TransactionResultDto(
+                transactionId = transaction.id,
+                status = TransactionStatus.COMPLETED.name,
+                newBalance = credit.balance,
+                message = "크레딧 충전이 완료되었습니다"
+            )
+        } catch (e: Exception) {
+            // 오류 발생 시 트랜잭션 상태 업데이트
+            transaction.status = TransactionStatus.FAILED
+            transaction.updatedAt = OffsetDateTime.now()
+            creditTransactionRepository.save(transaction)
+            
+            logger.error("크레딧 충전 실패: userId={}, amount={}, error={}", 
+                user.id, request.amount, e.message, e)
+            
+            throw RuntimeException("크레딧 충전 중 오류가 발생했습니다: ${e.message}", e)
+        }
+    }
+    
+    /**
+     * 크레딧을 사용합니다.
+     */
+    @Transactional
+    fun useCredits(request: UseCreditsRequest): TransactionResultDto {
+        logger.info("크레딧 사용 요청: {}", request)
+        
+        if (request.amount <= 0) {
+            throw IllegalArgumentException("사용 금액은 양수여야 합니다")
+        }
+        
+        val user = findUser(request.userId)
+        val credit = findOrCreateUserCredit(user.id)
+        val balanceBefore = credit.balance
+        
+        // 잔액 확인
+        if (balanceBefore < request.amount) {
+            logger.warn("크레딧 부족: userId={}, required={}, balance={}", 
+                user.id, request.amount, balanceBefore)
+            
+            // 실패 트랜잭션 기록
+            val failedTransaction = CreditTransaction(
+                user = user,
+                amount = request.amount,
+                type = TransactionType.PURCHASE,
+                referenceId = request.referenceId,
+                referenceType = request.referenceType,
+                description = request.description ?: "크레딧 사용 시도",
+                status = TransactionStatus.FAILED,
+                balanceBefore = balanceBefore
+            )
+            creditTransactionRepository.save(failedTransaction)
+            
+            throw IllegalStateException("크레딧이 부족합니다 (필요: ${request.amount}, 보유: $balanceBefore)")
+        }
+        
+        // 트랜잭션 기록 생성
+        val transaction = CreditTransaction(
+            user = user,
+            amount = request.amount,
+            type = TransactionType.PURCHASE,
+            referenceId = request.referenceId,
+            referenceType = request.referenceType,
+            description = request.description ?: "크레딧 사용",
+            status = TransactionStatus.PENDING,
+            balanceBefore = balanceBefore
+        )
+        creditTransactionRepository.save(transaction)
+        
+        try {
+            // 크레딧 잔액 업데이트
+            val time = OffsetDateTime.now()
+
+            credit.balance -= request.amount
+            credit.updatedAt = time
+            creditRepository.save(credit)
+            
+            // 트랜잭션 상태 업데이트
+            transaction.status = TransactionStatus.COMPLETED
+            transaction.balanceAfter = credit.balance
+            transaction.updatedAt = time
+            creditTransactionRepository.save(transaction)
+            
+            logger.info("크레딧 사용 성공: userId={}, amount={}, newBalance={}, referenceType={}, referenceId={}", 
+                user.id, request.amount, credit.balance, request.referenceType, request.referenceId)
+            
+            return TransactionResultDto(
+                transactionId = transaction.id,
+                status = TransactionStatus.COMPLETED.name,
+                newBalance = credit.balance,
+                message = "크레딧 사용이 완료되었습니다"
+            )
+        } catch (e: Exception) {
+            // 오류 발생 시 트랜잭션 상태 업데이트
+            transaction.status = TransactionStatus.FAILED
+            transaction.updatedAt = OffsetDateTime.now()
+            creditTransactionRepository.save(transaction)
+            
+            logger.error("크레딧 사용 실패: userId={}, amount={}, error={}", 
+                user.id, request.amount, e.message, e)
+            
+            throw RuntimeException("크레딧 사용 중 오류가 발생했습니다: ${e.message}", e)
+        }
+    }
+    
+    /**
+     * 크레딧 거래 내역을 조회합니다.
+     */
+    @Transactional(readOnly = true)
+    fun getTransactionHistory(request: GetTransactionsRequest): Page<CreditTransactionDto> {
+        logger.info("크레딧 거래 내역 조회: {}", request)
+        
+        val pageable = PageRequest.of(request.page, request.size)
+        
+        // 조회 조건에 따라 다른 메서드 호출
+        val transactions = when {
+            // 날짜 범위로 필터링
+            request.startDate != null && request.endDate != null -> {
+                val startDate = OffsetDateTime.parse(request.startDate)
+                val endDate = OffsetDateTime.parse(request.endDate)
+                creditTransactionRepository.findByUserIdAndCreatedAtBetween(
+                    request.userId, startDate, endDate, pageable
+                )
+            }
+            // 타입으로 필터링
+            request.type != null -> {
+                val type = TransactionType.valueOf(request.type)
+                creditTransactionRepository.findByUserIdAndType(
+                    request.userId, type, pageable
+                )
+            }
+            // 상태로 필터링
+            request.status != null -> {
+                val status = TransactionStatus.valueOf(request.status)
+                creditTransactionRepository.findByUserIdAndStatus(
+                    request.userId, status, pageable
+                )
+            }
+            // 모든 거래 내역
+            else -> {
+                creditTransactionRepository.findByUserId(request.userId, pageable)
+            }
+        }
+        
+        return transactions.map { CreditTransactionDto.fromEntity(it) }
+    }
+    
+    /**
+     * 사용자 크레딧 정보를 찾거나, 없으면 생성합니다.
+     */
+    @Transactional
+    fun findOrCreateUserCredit(userId: Long): Credit {
+        val user = findUser(userId)
+        
+        val credit = creditRepository.findByUserId(userId)
+        if (credit.isPresent) {
+            return credit.get()
+        }
+        
+        // 새 크레딧 계정 생성
+        val newCredit = Credit(
+            user = user,
+            balance = 0
+        )
+        return creditRepository.save(newCredit)
+    }
+    
+    /**
+     * 사용자 정보를 조회합니다.
+     */
+    private fun findUser(userId: Long): User {
+        return userRepository.findById(userId)
+            .orElseThrow { IllegalArgumentException("사용자를 찾을 수 없습니다: $userId") }
+    }
+    
+    /**
+     * 크레딧을 현금으로 환전합니다.
+     */
+    @Transactional
+    fun exchangeCredits(request: ExchangeCreditsRequest): TransactionResultDto {
+        logger.info("크레딧 환전 요청: {}", request)
+        
+        if (request.amount <= 0) {
+            throw IllegalArgumentException("환전 금액은 양수여야 합니다")
+        }
+        
+        // 최소 환전 금액 확인 (예: 1000 크레딧 이상)
+        val minExchangeAmount = 1000
+        if (request.amount < minExchangeAmount) {
+            throw IllegalArgumentException("최소 환전 금액은 $minExchangeAmount 크레딧입니다")
+        }
+        
+        val user = findUser(request.userId)
+        val credit = findOrCreateUserCredit(user.id)
+        val balanceBefore = credit.balance
+        
+        // 잔액 확인
+        if (balanceBefore < request.amount) {
+            logger.warn("크레딧 부족: userId={}, required={}, balance={}", 
+                user.id, request.amount, balanceBefore)
+            
+            // 실패 트랜잭션 기록
+            val failedTransaction = CreditTransaction(
+                user = user,
+                amount = request.amount,
+                type = TransactionType.EXCHANGE,
+                description = "크레딧 환전 시도 (${request.bankName ?: ""}, ${request.accountNumber ?: ""})",
+                status = TransactionStatus.FAILED,
+                balanceBefore = balanceBefore
+            )
+            creditTransactionRepository.save(failedTransaction)
+            
+            throw IllegalStateException("크레딧이 부족합니다 (필요: ${request.amount}, 보유: $balanceBefore)")
+        }
+        
+        // 트랜잭션 기록 생성
+        val transaction = CreditTransaction(
+            user = user,
+            amount = request.amount,
+            type = TransactionType.EXCHANGE,
+            description = "크레딧 환전 (${request.bankName ?: ""}, ${request.accountNumber ?: ""}, ${request.accountHolder ?: ""})",
+            status = TransactionStatus.PENDING,
+            balanceBefore = balanceBefore
+        )
+        creditTransactionRepository.save(transaction)
+        
+        try {
+            // 크레딧 잔액 업데이트
+            val time = OffsetDateTime.now()
+
+            credit.balance -= request.amount
+            credit.updatedAt = time
+            creditRepository.save(credit)
+            
+            // 실제 환전 처리 로직은 여기에 구현
+            // 외부 결제 시스템이나 관리자 승인 프로세스 연동 등
+            
+            // 트랜잭션 상태 업데이트
+            transaction.status = TransactionStatus.COMPLETED
+            transaction.balanceAfter = credit.balance
+            transaction.updatedAt = time
+            creditTransactionRepository.save(transaction)
+            
+            logger.info("크레딧 환전 요청 성공: userId={}, amount={}, newBalance={}, bank={}, account={}", 
+                user.id, request.amount, credit.balance, request.bankName, request.accountNumber)
+            
+            return TransactionResultDto(
+                transactionId = transaction.id,
+                status = TransactionStatus.COMPLETED.name,
+                newBalance = credit.balance,
+                message = "크레딧 환전 요청이 완료되었습니다. 처리 후 지정된 계좌로 입금됩니다."
+            )
+        } catch (e: Exception) {
+            // 오류 발생 시 트랜잭션 상태 업데이트
+            transaction.status = TransactionStatus.FAILED
+            transaction.updatedAt = OffsetDateTime.now()
+            creditTransactionRepository.save(transaction)
+            
+            logger.error("크레딧 환전 실패: userId={}, amount={}, error={}", 
+                user.id, request.amount, e.message, e)
+            
+            throw RuntimeException("크레딧 환전 중 오류가 발생했습니다: ${e.message}", e)
+        }
+    }
+} 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/service/CreditService.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/service/CreditService.kt
@@ -6,13 +6,18 @@ import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.CreditTransacti
 import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.ReferenceType
 import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.TransactionStatus
 import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.TransactionType
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.CreditExchangeRequest
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.model.ExchangeStatus
 import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.repository.CreditRepository
 import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.repository.CreditTransactionRepository
+import kr.ac.kookmin.cs.capstone.voicepack_platform.credit.repository.CreditExchangeRequestRepository
+import kr.ac.kookmin.cs.capstone.voicepack_platform.sale.SaleRepository
 import kr.ac.kookmin.cs.capstone.voicepack_platform.user.User
 import kr.ac.kookmin.cs.capstone.voicepack_platform.user.UserRepository
 import org.slf4j.LoggerFactory
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.OffsetDateTime
@@ -22,6 +27,8 @@ import java.time.format.DateTimeFormatter
 class CreditService(
     private val creditRepository: CreditRepository,
     private val creditTransactionRepository: CreditTransactionRepository,
+    private val creditExchangeRequestRepository: CreditExchangeRequestRepository,
+    private val saleRepository: SaleRepository,
     private val userRepository: UserRepository
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
@@ -57,9 +64,11 @@ class CreditService(
             user = user,
             amount = request.amount,
             type = TransactionType.CHARGE,
-            description = "크레딧 충전: ${request.paymentMethod ?: "일반"}",
+            description = request.paymentMethod ?: "크레딧 충전: 일반",
             status = TransactionStatus.PENDING,
-            balanceBefore = balanceBefore
+            balanceBefore = balanceBefore,
+            referenceId = request.paymentReference?.toLong(),
+            referenceType = if (request.paymentMethod?.contains("보이스팩") == true) ReferenceType.VOICEPACK else ReferenceType.PAYMENT
         )
         creditTransactionRepository.save(transaction)
         
@@ -105,14 +114,14 @@ class CreditService(
      * 크레딧을 사용합니다.
      */
     @Transactional
-    fun useCredits(request: UseCreditsRequest): TransactionResultDto {
+    fun useCredits(userId: Long, request: UseCreditsRequest): TransactionResultDto {
         logger.info("크레딧 사용 요청: {}", request)
         
         if (request.amount <= 0) {
             throw IllegalArgumentException("사용 금액은 양수여야 합니다")
         }
         
-        val user = findUser(request.userId)
+        val user = findUser(userId)
         val credit = findOrCreateUserCredit(user.id)
         val balanceBefore = credit.balance
         
@@ -196,44 +205,35 @@ class CreditService(
     
     /**
      * 크레딧 거래 내역을 조회합니다.
+     * TODO: Page<CreditTransactionDto> 대신 CreditHistoryDto 반환하도록 수정 필요
      */
     @Transactional(readOnly = true)
-    fun getTransactionHistory(request: GetTransactionsRequest): Page<CreditTransactionDto> {
-        logger.info("크레딧 거래 내역 조회: {}", request)
+    fun getTransactionHistory(userId: Long): CreditHistoryDto {
+        logger.info("크레딧 거래 내역 조회: userId={}", userId)
         
-        val pageable = PageRequest.of(request.page, request.size)
+        // 사용자의 모든 완료된 거래 내역 조회 (최신순)
+        // TODO: 페이징 처리 필요 시 추가 고려
+        val transactions = creditTransactionRepository.findByUserIdAndStatusOrderByCreatedAtDesc(userId, TransactionStatus.COMPLETED)
         
-        // 조회 조건에 따라 다른 메서드 호출
-        val transactions = when {
-            // 날짜 범위로 필터링
-            request.startDate != null && request.endDate != null -> {
-                val startDate = OffsetDateTime.parse(request.startDate)
-                val endDate = OffsetDateTime.parse(request.endDate)
-                creditTransactionRepository.findByUserIdAndCreatedAtBetween(
-                    request.userId, startDate, endDate, pageable
-                )
-            }
-            // 타입으로 필터링
-            request.type != null -> {
-                val type = TransactionType.valueOf(request.type)
-                creditTransactionRepository.findByUserIdAndType(
-                    request.userId, type, pageable
-                )
-            }
-            // 상태로 필터링
-            request.status != null -> {
-                val status = TransactionStatus.valueOf(request.status)
-                creditTransactionRepository.findByUserIdAndStatus(
-                    request.userId, status, pageable
-                )
-            }
-            // 모든 거래 내역
-            else -> {
-                creditTransactionRepository.findByUserId(request.userId, pageable)
-            }
+        val charges = transactions.filter { it.type == TransactionType.CHARGE || it.type == TransactionType.SALE_INCOME }.map { 
+            // TODO: ChargeDto의 amountWon, method 필드 채우는 로직 필요 (description 파싱 등)
+            ChargeDto(
+                date = it.createdAt,
+                amountWon = null, // 임시
+                amountCredit = it.amount,
+                method = it.description // 임시
+            )
         }
         
-        return transactions.map { CreditTransactionDto.fromEntity(it) }
+        val usages = transactions.filter { it.type == TransactionType.PURCHASE || it.type == TransactionType.EXCHANGE }.map { 
+            UsageDto(
+                date = it.createdAt,
+                usage = it.description,
+                amountCredit = it.amount
+            )
+        }
+        
+        return CreditHistoryDto(charges = charges, usages = usages)
     }
     
     /**
@@ -254,101 +254,108 @@ class CreditService(
             .orElseThrow { IllegalArgumentException("사용자를 찾을 수 없습니다: $userId") }
     }
     
-    /**
-     * 크레딧을 현금으로 환전합니다.
-     */
+    // 사용자 총 수입 조회 (판매 수익 합계)
+    @Transactional(readOnly = true)
+    fun getTotalEarnings(userId: Long): Int {
+        logger.info("총 수입 조회: userId={}", userId)
+        return saleRepository.sumAmountBySellerId(userId) ?: 0 
+        
+    }
+
+    // API 요구사항 9번: 크레딧 환전 신청 요청
     @Transactional
-    fun exchangeCredits(request: ExchangeCreditsRequest): TransactionResultDto {
-        logger.info("크레딧 환전 요청: {}", request)
-        
-        if (request.amount <= 0) {
-            throw IllegalArgumentException("환전 금액은 양수여야 합니다")
+    fun requestCreditExchange(userId: Long, request: CreditExchangeRequestRequestDto): CreditExchangeResponseDto {
+        logger.info("크레딧 환전 신청 요청: userId={}, requestCredit={}", userId, request.credit)
+
+        if (request.credit <= 0) {
+            throw IllegalArgumentException("환전 신청 크레딧은 양수여야 합니다")
         }
         
-        // 최소 환전 금액 확인 (예: 1000 크레딧 이상)
-        val minExchangeAmount = 1000
-        if (request.amount < minExchangeAmount) {
-            throw IllegalArgumentException("최소 환전 금액은 $minExchangeAmount 크레딧입니다")
-        }
+        // TODO: 환전 비율 적용하여 원화 계산 (예: 1 크레딧 = 100원)
+        val exchangeRate = 100
+        val wonAmount = request.credit * exchangeRate
         
-        val user = findUser(request.userId)
+        val user = findUser(userId)
         val credit = findOrCreateUserCredit(user.id)
         val balanceBefore = credit.balance
         
         // 잔액 확인
-        if (balanceBefore < request.amount) {
-            logger.warn("크레딧 부족: userId={}, required={}, balance={}", 
-                user.id, request.amount, balanceBefore)
-            
-            // 실패 트랜잭션 기록
-            val failedTransaction = CreditTransaction(
-                user = user,
-                amount = request.amount,
-                type = TransactionType.EXCHANGE,
-                description = "크레딧 환전 시도 (${request.bankName ?: ""}, ${request.accountNumber ?: ""})",
-                status = TransactionStatus.FAILED,
-                balanceBefore = balanceBefore,
-                balanceAfter = balanceBefore // 잔액 변동 없음
-            )
-            // 별도 트랜잭션으로 저장하여 롤백 방지
-            creditTransactionRepository.saveAndFlush(failedTransaction)
-            
-            // 결과 DTO 반환 (트랜잭션 롤백되지 않음)
-            return TransactionResultDto(
-                transactionId = failedTransaction.id,
-                status = TransactionStatus.FAILED.name,
-                newBalance = balanceBefore,
-                message = "크레딧이 부족합니다 (필요: ${request.amount}, 보유: $balanceBefore)"
-            )
+        if (balanceBefore < request.credit) {
+            logger.warn("크레딧 부족 (환전): userId={}, required={}, balance={}", 
+                user.id, request.credit, balanceBefore)
+            // 실패 시에는 별도 트랜잭션 기록 없이 예외 발생 또는 실패 응답 반환
+            throw IllegalStateException("환전 신청 실패: 크레딧이 부족합니다 (필요: ${request.credit}, 보유: $balanceBefore)")
         }
         
-        // 트랜잭션 기록 생성
-        val transaction = CreditTransaction(
+        // CreditExchangeRequest 생성 및 저장
+        val exchangeRequest = CreditExchangeRequest(
             user = user,
-            amount = request.amount,
-            type = TransactionType.EXCHANGE,
-            description = "크레딧 환전 (${request.bankName ?: ""}, ${request.accountNumber ?: ""}, ${request.accountHolder ?: ""})",
-            status = TransactionStatus.PENDING,
-            balanceBefore = balanceBefore
+            creditAmount = request.credit,
+            wonAmount = wonAmount,
+            status = ExchangeStatus.PENDING, // 초기 상태는 PENDING
+            // TODO: request에서 bankName, accountNumber, accountHolder 정보 받아와서 저장
+            bankName = request.bankName,
+            accountNumber = request.accountNumber,
+            accountHolder = request.accountHolder
         )
-        creditTransactionRepository.save(transaction)
+        val savedExchangeRequest = creditExchangeRequestRepository.save(exchangeRequest) // 저장 후 ID 사용
+        logger.info("환전 신청 기록 저장: userId={}, credit={}, won={}, status={}, requestId={}", 
+            userId, request.credit, wonAmount, exchangeRequest.status, savedExchangeRequest.id)
         
-        try {
-            // 크레딧 잔액 업데이트
-            val time = OffsetDateTime.now()
-
-            credit.balance -= request.amount
-            credit.updatedAt = time
-            creditRepository.save(credit)
-            
-            // 실제 환전 처리 로직은 여기에 구현
-            // 외부 결제 시스템이나 관리자 승인 프로세스 연동 등
-            
-            // 트랜잭션 상태 업데이트
-            transaction.status = TransactionStatus.COMPLETED
-            transaction.balanceAfter = credit.balance
-            transaction.updatedAt = time
-            creditTransactionRepository.save(transaction)
-            
-            logger.info("크레딧 환전 요청 성공: userId={}, amount={}, newBalance={}, bank={}, account={}", 
-                user.id, request.amount, credit.balance, request.bankName, request.accountNumber)
-            
-            return TransactionResultDto(
-                transactionId = transaction.id,
-                status = TransactionStatus.COMPLETED.name,
-                newBalance = credit.balance,
-                message = "크레딧 환전 요청이 완료되었습니다. 처리 후 지정된 계좌로 입금됩니다."
-            )
-        } catch (e: Exception) {
-            // 오류 발생 시 트랜잭션 상태 업데이트
-            transaction.status = TransactionStatus.FAILED
-            transaction.updatedAt = OffsetDateTime.now()
-            creditTransactionRepository.save(transaction)
-            
-            logger.error("크레딧 환전 실패: userId={}, amount={}, error={}", 
-                user.id, request.amount, e.message, e)
-            
-            throw RuntimeException("크레딧 환전 중 오류가 발생했습니다: ${e.message}", e)
+        // 크레딧 차감 (환전 신청 시점에 즉시 차감)
+        val useCreditResult = useCredits(userId, UseCreditsRequest(
+            amount = request.credit,
+            referenceId = savedExchangeRequest.id, // 생성된 환전 요청 ID 참조
+            referenceType = ReferenceType.CREDIT_EXCHANGE,
+            description = "크레딧 환전 신청"
+        ))
+        
+        if (useCreditResult.status == TransactionStatus.FAILED.name) {
+            // 이 경우는 잔액 부족 외 다른 이유로 차감 실패 시
+            logger.error("환전 신청 실패: 크레딧 차감 중 오류 발생 - userId={}, credit={}", userId, request.credit)
+            // TODO: 생성된 exchangeRequest 상태를 REJECTED로 변경하거나 삭제하는 로직 추가 고려
+            throw RuntimeException("환전 신청 처리 중 오류가 발생했습니다: ${useCreditResult.message}")
         }
+        
+        // 성공 응답 반환
+        return CreditExchangeResponseDto(
+            message = "환전 신청이 완료되었습니다. 처리 후 입금됩니다.",
+            won = wonAmount
+        )
+    }
+    
+    // API 요구사항 8번: 크레딧 환전 신청 내역 조회
+    @Transactional(readOnly = true)
+    fun getCreditExchangeRequests(userId: Long, pageable: Pageable): Page<CreditExchangeRequestDto> {
+        logger.info("환전 신청 내역 조회: userId={}, page={}, size={}", userId, pageable.pageNumber, pageable.pageSize)
+        val requestsPage = creditExchangeRequestRepository.findByUserIdOrderByRequestDateDesc(userId, pageable)
+        return requestsPage.map { CreditExchangeRequestDto.fromEntity(it) }
+    }
+    
+    // API 요구사항 10번: 크레딧 충전 요청
+    // TODO: 실제 결제 시스템 연동 필요
+    fun requestCreditCharge(userId: Long, request: CreditChargeRequestDto): Map<String, Any> {
+        logger.info("크레딧 충전 요청 시작: userId={}, amount={}, method={}", userId, request.amount, request.method)
+        
+        if (request.amount <= 0) {
+            throw IllegalArgumentException("충전 금액은 양수여야 합니다.")
+        }
+        val user = findUser(userId) // 사용자가 존재하는지 확인
+        
+        // TODO: 결제 정보 생성 (주문 ID 등)
+        val orderId = "temp_order_${System.currentTimeMillis()}" 
+        
+        // TODO: 결제 모듈 호출 및 결제 페이지 URL 또는 정보 반환
+        // 현재는 임시로 성공 메시지와 주문 ID 반환
+        val response = mapOf(
+            "message" to "결제 요청이 생성되었습니다. 결제를 진행해주세요.",
+            "orderId" to orderId,
+            "amount" to request.amount,
+            "paymentMethod" to request.method,
+            "nextRedirectUrl" to "/payment/process?orderId=$orderId" // 예시 URL
+        )
+        
+        logger.info("크레딧 충전 요청 생성 완료: userId={}, orderId={}", userId, orderId)
+        return response
     }
 } 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/service/CreditService.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/service/CreditService.kt
@@ -130,11 +130,19 @@ class CreditService(
                 referenceType = request.referenceType,
                 description = request.description ?: "크레딧 사용 시도",
                 status = TransactionStatus.FAILED,
-                balanceBefore = balanceBefore
+                balanceBefore = balanceBefore,
+                balanceAfter = balanceBefore // 잔액 변동 없음
             )
-            creditTransactionRepository.save(failedTransaction)
+            // 별도 트랜잭션으로 저장하여 롤백 방지
+            creditTransactionRepository.saveAndFlush(failedTransaction)
             
-            throw IllegalStateException("크레딧이 부족합니다 (필요: ${request.amount}, 보유: $balanceBefore)")
+            // 결과 DTO 반환 (트랜잭션 롤백되지 않음)
+            return TransactionResultDto(
+                transactionId = failedTransaction.id,
+                status = TransactionStatus.FAILED.name,
+                newBalance = balanceBefore,
+                message = "크레딧이 부족합니다 (필요: ${request.amount}, 보유: $balanceBefore)"
+            )
         }
         
         // 트랜잭션 기록 생성
@@ -289,11 +297,19 @@ class CreditService(
                 type = TransactionType.EXCHANGE,
                 description = "크레딧 환전 시도 (${request.bankName ?: ""}, ${request.accountNumber ?: ""})",
                 status = TransactionStatus.FAILED,
-                balanceBefore = balanceBefore
+                balanceBefore = balanceBefore,
+                balanceAfter = balanceBefore // 잔액 변동 없음
             )
-            creditTransactionRepository.save(failedTransaction)
+            // 별도 트랜잭션으로 저장하여 롤백 방지
+            creditTransactionRepository.saveAndFlush(failedTransaction)
             
-            throw IllegalStateException("크레딧이 부족합니다 (필요: ${request.amount}, 보유: $balanceBefore)")
+            // 결과 DTO 반환 (트랜잭션 롤백되지 않음)
+            return TransactionResultDto(
+                transactionId = failedTransaction.id,
+                status = TransactionStatus.FAILED.name,
+                newBalance = balanceBefore,
+                message = "크레딧이 부족합니다 (필요: ${request.amount}, 보유: $balanceBefore)"
+            )
         }
         
         // 트랜잭션 기록 생성

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/service/CreditService.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/credit/service/CreditService.kt
@@ -243,17 +243,7 @@ class CreditService(
     fun findOrCreateUserCredit(userId: Long): Credit {
         val user = findUser(userId)
         
-        val credit = creditRepository.findByUserId(userId)
-        if (credit.isPresent) {
-            return credit.get()
-        }
-        
-        // 새 크레딧 계정 생성
-        val newCredit = Credit(
-            user = user,
-            balance = 0
-        )
-        return creditRepository.save(newCredit)
+        return creditRepository.findByUserId(userId) ?: creditRepository.save(Credit(user = user, balance = 0))
     }
     
     /**

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/sale/Sale.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/sale/Sale.kt
@@ -1,0 +1,32 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.sale
+
+import jakarta.persistence.*
+import kr.ac.kookmin.cs.capstone.voicepack_platform.user.User
+import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.Voicepack
+import java.time.OffsetDateTime
+
+@Entity
+@Table(name = "sales")
+data class Sale(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seller_id", nullable = false)
+    val seller: User, // 판매자 (보이스팩 제작자)
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "buyer_id", nullable = false)
+    val buyer: User, // 구매자
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "voicepack_id", nullable = false)
+    val voicepack: Voicepack, // 판매된 보이스팩
+
+    @Column(name = "amount", nullable = false)
+    val amount: Int, // 판매 금액 (크레딧)
+
+    @Column(name = "transaction_date", nullable = false)
+    val transactionDate: OffsetDateTime = OffsetDateTime.now() // 판매 시점
+) 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/sale/SaleRepository.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/sale/SaleRepository.kt
@@ -1,0 +1,26 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.sale
+
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import java.time.OffsetDateTime
+
+@Repository
+interface SaleRepository : JpaRepository<Sale, Long> {
+
+    // 판매자 ID로 판매 내역 조회 (페이징 및 최신순 정렬)
+    fun findBySellerIdOrderByTransactionDateDesc(sellerId: Long, pageable: Pageable): Page<Sale>
+
+    // 판매자 ID로 총 판매 금액 합계 조회
+    @Query("SELECT SUM(s.amount) FROM Sale s WHERE s.seller.id = :sellerId")
+    fun sumAmountBySellerId(sellerId: Long): Int? // 결과가 없을 수 있으므로 Nullable
+
+    // 판매자 ID와 특정 기간으로 판매 금액 합계 조회
+    @Query("SELECT SUM(s.amount) FROM Sale s WHERE s.seller.id = :sellerId AND s.transactionDate BETWEEN :startDate AND :endDate")
+    fun sumAmountBySellerIdAndTransactionDateBetween(sellerId: Long, startDate: OffsetDateTime, endDate: OffsetDateTime): Int?
+
+    // 판매자 ID로 총 판매 건수 조회
+    fun countBySellerId(sellerId: Long): Long
+} 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/sale/controller/SalesController.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/sale/controller/SalesController.kt
@@ -1,0 +1,58 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.sale.controller
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.tags.Tag
+import kr.ac.kookmin.cs.capstone.voicepack_platform.sale.dto.SaleDto
+import kr.ac.kookmin.cs.capstone.voicepack_platform.sale.dto.SalesSummaryDto
+import kr.ac.kookmin.cs.capstone.voicepack_platform.sale.service.SalesService
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/sales")
+@Tag(name = "판매 관리", description = "보이스팩 판매 내역 및 통계 관련 API")
+class SalesController(
+    private val salesService: SalesService
+) {
+
+    @Operation(
+        summary = "판매 내역 조회",
+        description = "사용자의 보이스팩 판매 내역을 페이지네이션하여 조회합니다.",
+    )
+    @GetMapping("") // API 명세상 /api/sales 와 /api/sales/list 가 유사하여 통합
+    fun getSalesHistory(
+        @Parameter(description = "판매자(로그인 사용자) ID") @RequestParam sellerId: Long, // TODO: 인증 정보 사용
+        @Parameter(required = false, description = "페이지 정보", example = """
+            {
+                "page": 0,
+                "size": 10,
+                "sort": [
+                    "transactionDate"
+                ]
+            }
+        """
+        ) @PageableDefault(size = 10, sort = ["transactionDate"]) pageable: Pageable // 기본 10개, 날짜 정렬
+    ): ResponseEntity<Page<SaleDto>> {
+        val salesHistory = salesService.getSalesHistory(sellerId, pageable)
+        return ResponseEntity.ok(salesHistory)
+    }
+
+    @Operation(
+        summary = "판매 통계 조회",
+        description = "사용자의 총 수익, 이번 달 수익, 총 판매 건수 통계를 조회합니다."
+    )
+    @GetMapping("/summary")
+    fun getSalesSummary(
+        @Parameter(description = "판매자(로그인 사용자) ID") @RequestParam sellerId: Long // TODO: 인증 정보 사용
+    ): ResponseEntity<SalesSummaryDto> {
+        val summary = salesService.getSalesSummary(sellerId)
+        return ResponseEntity.ok(summary)
+    }
+} 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/sale/dto/SaleDto.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/sale/dto/SaleDto.kt
@@ -1,0 +1,34 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.sale.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import kr.ac.kookmin.cs.capstone.voicepack_platform.sale.Sale
+import java.time.OffsetDateTime
+
+data class SaleDto(
+    @Schema(description = "판매 기록 ID", example = "1")
+    val id: Long,
+    
+    @Schema(description = "판매 일시")
+    val date: OffsetDateTime,
+    
+    @Schema(description = "판매된 보이스팩 이름", example = "감성 보이스")
+    val voicepackName: String,
+    
+    @Schema(description = "구매자 이메일", example = "buyer@example.com") // 구매자 ID 대신 이메일 사용
+    val buyerEmail: String,
+    
+    @Schema(description = "판매 금액 (크레딧)", example = "100")
+    val amount: Int
+) {
+    companion object {
+        fun fromEntity(sale: Sale): SaleDto {
+            return SaleDto(
+                id = sale.id,
+                date = sale.transactionDate,
+                voicepackName = sale.voicepack.name,
+                buyerEmail = sale.buyer.email, // 구매자 이메일로 변경
+                amount = sale.amount
+            )
+        }
+    }
+} 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/sale/dto/SalesSummaryDto.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/sale/dto/SalesSummaryDto.kt
@@ -1,0 +1,14 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.sale.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class SalesSummaryDto(
+    @Schema(description = "총 수익 (크레딧)", example = "320")
+    val totalRevenue: Int,
+    
+    @Schema(description = "이번 달 수익 (크레딧)", example = "200")
+    val monthlyRevenue: Int,
+    
+    @Schema(description = "총 판매 건수", example = "5")
+    val salesCount: Long
+) 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/sale/service/SalesService.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/sale/service/SalesService.kt
@@ -1,0 +1,48 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.sale.service
+
+import kr.ac.kookmin.cs.capstone.voicepack_platform.sale.SaleRepository
+import kr.ac.kookmin.cs.capstone.voicepack_platform.sale.dto.SaleDto
+import kr.ac.kookmin.cs.capstone.voicepack_platform.sale.dto.SalesSummaryDto
+import org.slf4j.LoggerFactory
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.OffsetDateTime
+import java.time.temporal.TemporalAdjusters
+
+@Service
+class SalesService(
+    private val saleRepository: SaleRepository
+) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    @Transactional(readOnly = true)
+    fun getSalesHistory(sellerId: Long, pageable: Pageable): Page<SaleDto> {
+        logger.info("판매 내역 조회: sellerId={}, page={}, size={}", sellerId, pageable.pageNumber, pageable.pageSize)
+        val salesPage = saleRepository.findBySellerIdOrderByTransactionDateDesc(sellerId, pageable)
+        return salesPage.map { SaleDto.fromEntity(it) }
+    }
+
+    @Transactional(readOnly = true)
+    fun getSalesSummary(sellerId: Long): SalesSummaryDto {
+        logger.info("판매 통계 조회: sellerId={}", sellerId)
+
+        val totalRevenue = saleRepository.sumAmountBySellerId(sellerId) ?: 0
+
+        // 이번 달 수익 계산
+        val now = OffsetDateTime.now()
+        val firstDayOfMonth = now.with(TemporalAdjusters.firstDayOfMonth()).withHour(0).withMinute(0).withSecond(0).withNano(0)
+        val lastDayOfMonth = now.with(TemporalAdjusters.lastDayOfMonth()).withHour(23).withMinute(59).withSecond(59).withNano(999999999)
+        val monthlyRevenue = saleRepository.sumAmountBySellerIdAndTransactionDateBetween(sellerId, firstDayOfMonth, lastDayOfMonth) ?: 0
+
+        val salesCount = saleRepository.countBySellerId(sellerId)
+
+        logger.info("판매 통계 조회 완료: sellerId={}, total={}, monthly={}, count={}", sellerId, totalRevenue, monthlyRevenue, salesCount)
+        return SalesSummaryDto(
+            totalRevenue = totalRevenue,
+            monthlyRevenue = monthlyRevenue,
+            salesCount = salesCount
+        )
+    }
+} 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/user/User.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/user/User.kt
@@ -9,9 +9,15 @@ data class User(
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0,
 
+    @Column(nullable = true)
+    var name: String? = null,
+
     @Column(nullable = false, unique = true)
     val email: String,
 
     @Column(nullable = false)
-    val password: String
+    val password: String,
+
+    @Column(name = "profile_image_url")
+    var profileImageUrl: String? = null
 ) 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/user/UserController.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/user/UserController.kt
@@ -8,9 +8,18 @@ import jakarta.validation.Valid
 import kr.ac.kookmin.cs.capstone.voicepack_platform.user.dto.UserLoginRequest
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import kr.ac.kookmin.cs.capstone.voicepack_platform.user.dto.UserProfileDto
+import java.util.NoSuchElementException
 
 @RestController
 @RequestMapping("/api/users")
+@Tag(name = "사용자", description = "사용자 관련 API")
 class UserController(
     private val userService: UserService
 ) {
@@ -40,4 +49,30 @@ class UserController(
         return ResponseEntity.ok("현재 쿠키 값: $sessionCookie")
     }
 
+    @Operation(
+        summary = "내 정보 조회",
+        description = "로그인한 사용자의 정보와 활동 통계를 조회합니다.",
+        responses = [
+            ApiResponse(
+                responseCode = "200", 
+                description = "조회 성공",
+                content = [Content(schema = Schema(implementation = UserProfileDto::class))]
+            ),
+            ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음"),
+            ApiResponse(responseCode = "500", description = "서버 오류")
+        ]
+    )
+    @GetMapping("/me/{userId}")
+    fun getMyProfile(
+        @Parameter(description = "조회할 사용자 ID") @PathVariable userId: Long
+    ): ResponseEntity<Any> {
+        return try {
+            val userProfile = userService.getUserProfile(userId)
+            ResponseEntity.ok(userProfile)
+        } catch (e: NoSuchElementException) {
+            ResponseEntity.status(HttpStatus.NOT_FOUND).body(mapOf("error" to e.message))
+        } catch (e: Exception) {
+            ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(mapOf("error" to "프로필 조회 중 오류 발생"))
+        }
+    }
 } 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/user/dto/UserProfileDto.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/user/dto/UserProfileDto.kt
@@ -1,0 +1,29 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.user.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class UserProfileDto(
+    @Schema(description = "사용자 ID", example = "1")
+    val id: Long,
+    
+    @Schema(description = "사용자 이름", example = "박수연")
+    val name: String?,
+    
+    @Schema(description = "사용자 이메일", example = "suwith@kookmin.ac.kr")
+    val email: String,
+    
+    @Schema(description = "프로필 이미지 URL", example = "https://...")
+    val profileImageUrl: String?,
+    
+    @Schema(description = "보유 크레딧", example = "320")
+    val credit: Int,
+    
+    @Schema(description = "총 수입 (판매로 얻은 크레딧 합계)", example = "1200") // API 명세의 120000은 오타로 가정
+    val totalEarnings: Int, 
+    
+    @Schema(description = "생성한 보이스팩 수", example = "5")
+    val createdPacks: Int,
+    
+    @Schema(description = "구매한 보이스팩 수", example = "7")
+    val boughtPacks: Int
+) 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/Voicepack.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/Voicepack.kt
@@ -28,7 +28,7 @@ data class Voicepack(
     val createdAt: OffsetDateTime = OffsetDateTime.now(),
 
     @Column(name = "price", nullable = false)
-    val price: Int = 100
+    val price: Int = 100,
 
     @OneToMany(mappedBy = "voicepack", cascade = [CascadeType.REMOVE], orphanRemoval = true)
     val usageRights: MutableList<VoicepackUsageRight> = mutableListOf(),

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/Voicepack.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/Voicepack.kt
@@ -37,7 +37,8 @@ data class VoicepackDto(
     val id: Long,
     val name: String,
     val author: String,
-    val createdAt: OffsetDateTime
+    val createdAt: OffsetDateTime,
+    val price: Int
 ) {
     companion object {
         fun fromEntity(voicepack: Voicepack): VoicepackDto {
@@ -45,7 +46,8 @@ data class VoicepackDto(
                 id = voicepack.id,
                 name = voicepack.name,
                 author = voicepack.author.email,
-                createdAt = voicepack.createdAt
+                createdAt = voicepack.createdAt,
+                price = voicepack.price
             )
         }
     }

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/Voicepack.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/Voicepack.kt
@@ -27,8 +27,11 @@ data class Voicepack(
     @Column(name = "created_at", nullable = false)
     val createdAt: OffsetDateTime = OffsetDateTime.now(),
 
-    @Column(name = "price", nullable = false)
-    val price: Int = 100,
+    @Column(name = "price")
+    var price: Int? = 1000,
+
+    @Column(name = "is_public", nullable = false)
+    var isPublic: Boolean = true,
 
     @OneToMany(mappedBy = "voicepack", cascade = [CascadeType.REMOVE], orphanRemoval = true)
     val usageRights: MutableList<VoicepackUsageRight> = mutableListOf(),
@@ -47,7 +50,8 @@ data class VoicepackDto(
     val name: String,
     val author: String,
     val createdAt: OffsetDateTime,
-    val price: Int
+    val price: Int?,
+    val isPublic: Boolean
 ) {
     companion object {
         fun fromEntity(voicepack: Voicepack): VoicepackDto {
@@ -56,7 +60,8 @@ data class VoicepackDto(
                 name = voicepack.name,
                 author = voicepack.author.email,
                 createdAt = voicepack.createdAt,
-                price = voicepack.price
+                price = voicepack.price,
+                isPublic = voicepack.isPublic
             )
         }
     }

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/Voicepack.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/Voicepack.kt
@@ -23,7 +23,10 @@ data class Voicepack(
     val s3Path: String,
 
     @Column(name = "created_at", nullable = false)
-    val createdAt: OffsetDateTime = OffsetDateTime.now()
+    val createdAt: OffsetDateTime = OffsetDateTime.now(),
+
+    @Column(name = "price", nullable = false)
+    val price: Int = 100
 ) 
 
 /**

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackRepository.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackRepository.kt
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Repository
 interface VoicepackRepository : JpaRepository<Voicepack, Long> {
     fun existsByName(name: String): Boolean
     fun findByAuthorId(authorId: Long): List<Voicepack>
+    fun findByIsPublicTrue(): List<Voicepack>
+    fun countByAuthorId(authorId: Long): Int
 } 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackService.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackService.kt
@@ -159,7 +159,10 @@ class VoicepackService(
             createdAt = finishedTime
         )
         voicepackRepository.save(voicepack)
-        
+
+        // 사용권 부여
+        grantUsageRight(voicepackRequest.author.id, voicepack.id)
+
         // 알림 전송
         notificationService.notifyVoicepackComplete(voicepackRequest)
     }

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/dto/UpdateVoicepackPublicRequest.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/dto/UpdateVoicepackPublicRequest.kt
@@ -1,0 +1,8 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class UpdateVoicepackPublicRequest(
+    @Schema(description = "변경할 공개 여부 값", example = "true")
+    val isPublic: Boolean
+) 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/usageright/VoicepackUsageRightRepository.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/usageright/VoicepackUsageRightRepository.kt
@@ -1,8 +1,10 @@
 package kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.usageright
 
+import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.Voicepack
 import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.usageright.VoicepackUsageRight
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -18,7 +20,15 @@ interface VoicepackUsageRightRepository : JpaRepository<VoicepackUsageRight, Lon
         FROM VoicepackUsageRight v
         WHERE v.user.id = :userId
     """)
-    fun findVoicepackDtosByUserId(userId: Long): List<VoicepackUsageRightBriefDto>
+    fun findVoicepackDtosByUserId(@Param("userId") userId: Long): List<VoicepackUsageRightBriefDto>
+
+    // 사용자가 구매한 (즉, 자신이 생성하지 않은) 보이스팩 엔티티 목록 조회
+    @Query("SELECT DISTINCT vur.voicepack FROM VoicepackUsageRight vur WHERE vur.user.id = :userId AND vur.voicepack.author.id <> :userId")
+    fun findDistinctPurchasedVoicepacksByUserId(@Param("userId") userId: Long): List<Voicepack>
+
+    // 사용자가 구매한 (자신이 생성하지 않은) 보이스팩 개수 조회
+    @Query("SELECT COUNT(DISTINCT vur.voicepack.id) FROM VoicepackUsageRight vur WHERE vur.user.id = :userId AND vur.voicepack.author.id <> :userId")
+    fun countPurchasedVoicepacksByUserId(@Param("userId") userId: Long): Int
 
     // 특정 사용자가 보유한 모든 사용권 정보 조회 (페이지네이션 가능)
     // fun findByUserId(userId: Long, pageable: Pageable): Page<VoicepackUsageRight>


### PR DESCRIPTION
# 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈를 추가해주세요. (예: #123) 이슈 번호 앞에 Closes 작성하면 PR 머지할 때 자동으로 이슈가 닫힙니다.-->
Issue #97 
PR #44 가 Merge되기 전까지 Draft로 유지합니다.
---

# ✨ 작업 사항
<!-- 이 PR에서 작업한 내용을 자유롭게 정리해주세요. -->

본 PR은 기획 문서에 명시된 마이페이지의 주요 기능들을 구현합니다. 사용자의 활동 요약을 보여주는 대시보드부터 보이스팩 관리, 수입 관리, 크레딧 관리에 필요한 백엔드 API 및 관련 로직 변경 사항을 포함합니다.

**코드 추가 및 변경 사항이 매우 많습니다. 🙏** 

## 주요 변경 사항

### 1. 대시보드 및 사용자 정보 (`GET /api/users/me`)

*   **사용자 기본 정보 및 통계 제공:**
    *   `UserService` 및 `UserController`를 수정하여 `/api/users/me` 엔드포인트가 이름, 이메일, 프로필 이미지 외에 보유 크레딧, 총 수입, 생성/구매한 보이스팩 수를 반환하도록 개선했습니다. (`UserProfileDto` 추가)
    *   `VoicepackRepository` 및 `VoicepackUsageRightRepository`에 보이스팩 개수 조회를 위한 `countByAuthorId`, `countPurchasedVoicepacksByUserId` 메소드를 추가하고 `UserService`에서 사용합니다.
    *   `SaleRepository`를 통해 총 수입(`totalEarnings`)을 계산하는 로직이 `UserService` (또는 관련 서비스)에 반영되었습니다. (`getTotalEarnings` 호출 등)

### 2. 보이스팩 관리 (`GET /api/voicepacks`, `PATCH /api/voicepacks/:id`, `DELETE /api/voicepacks/:id`)

*   **목록 조회 필터링 강화:** `VoicepackService`의 `getVoicepacks` 메소드가 `filter` 파라미터 (`all`, `mine`, `purchased`)를 받아 동작하도록 개선되었습니다. (기반 로직은 이전 커밋에 포함)
    *   `purchased` 필터를 위해 `VoicepackUsageRightRepository`에 `findDistinctPurchasedVoicepacksByUserId` 메소드가 활용됩니다.
*   **공개 여부 변경 API (`PATCH`)**: 공개 여부 변경 API 관련 로직 및 DTO(`UpdateVoicepackPublicRequest`)가 포함됩니다. 비공개된 보이스팩은 전체 조회에서 조회되지 않습니다.
*   **삭제 API (`DELETE`)**: 이전 커밋(`feat: 보이스팩 가격...`)에서 추가된 삭제 API 관련 로직에 권한 확인 로직이 추가되었습니다.

### 3. 수입 관리 (`GET /api/sales`, `GET /api/sales/summary`)

*   **판매 모듈 추가:** 판매 내역(`Sale.kt`) 및 관련 레포지토리(`SaleRepository.kt`), 서비스, 컨트롤러, DTO가 `sale/` 패키지 하위에 추가되었습니다.
*   **판매 내역 API (`GET /api/sales`)**: 사용자의 판매 내역 목록을 조회하는 API가 구현되었습니다.
*   **수입 통계 API (`GET /api/sales/summary`)**: 총 수익, 월별 수익, 총 판매 건수 등을 조회하는 API가 구현되었습니다.
*   **보이스팩 구매 시 판매 기록 생성:** `VoicepackService`의 보이스팩 구매 로직(`purchaseVoicepack`) 내에서 구매 성공 시 `Sale` 엔티티를 생성하고 `SaleRepository`를 통해 저장하는 로직이 추가되었습니다.

### 4. 크레딧 관리 (`GET /api/credits/history`, `/api/credits/exchange-request`, `POST /api/credits/exchange-request`, `POST /api/credits/charge`)

*   **크레딧 충전 요청 API (`POST /api/credits/charge/{userId}`)**: 특정 사용자의 크레딧 충전 요청을 생성하는 API가 추가되었습니다. (`CreditChargeRequestDto` 추가)
    *   `CreditService`에 관련 로직 및 `CreditTransaction` 생성 시 결제 참조 정보(`paymentReference`, `referenceType`) 기록 로직이 추가되었습니다.
    *   기존 `/charge` 엔드포인트는 `@Deprecated` 처리했으나, 시연 등의 상황에서 이 엔드포인트로 Manual하게 충전 가능합니다..
*   **크레딧 환전 신청 API (`POST /api/credits/exchange-request/{userId}`)**: 특정 사용자의 크레딧 환전 신청을 처리하는 API가 추가되었습니다. (`CreditExchangeRequestRequestDto`, `CreditExchangeResponseDto` 추가)
    *   `CreditExchangeRequest` 엔티티 및 `CreditExchangeRequestRepository`가 추가되었습니다.
    *   `CreditService`에 환전 신청 처리 및 관련 `CreditTransaction` 생성 로직이 구현되었습니다.
    *   기존 `/exchange` 엔드포인트는 `@Deprecated` 처리되었습니다.
*   **환전 신청 내역 조회 API (`GET /api/credits/exchange-request/{userId}`)**: 사용자의 환전 신청 내역을 페이지네이션하여 조회하는 API가 추가되었습니다. (`CreditExchangeRequestDto` 추가)
*   **크레딧 거래 내역 조회 API (`GET /api/credits/history/{userId}`)**: 기존 거래 내역 조회 API가 개선되었습니다.
    *   엔드포인트 경로 변경 및 응답 형식이 `CreditHistoryDto` (충전/사용 분리)로 변경되었습니다.
    *   `CreditTransactionRepository`에 `findByUserIdAndStatusOrderByCreatedAtDesc` 메소드가 추가되었습니다.
*   **모델 업데이트:**
    *   `CreditTransaction`의 `TransactionType`에 `SALE_INCOME`이 추가되었습니다.
    *   `ReferenceType` enum 값이 재정의/정리되었습니다.

---

# 📸 스크린샷 (선택)
<!-- 변경된 UI나 버그 수정 전후 비교 화면이 있다면 추가해주세요. -->
<!-- 이미지는 이슈 제출 후 드래그 앤 드롭으로 업로드할 수 있습니다. -->

---

# 🔗 참고 자료 (선택)
<!-- 관련 문서, 디자인 시안, API 문서 등이 있다면 추가해주세요. -->
- 예: [Figma 디자인](https://www.figma.com/), [API 문서](https://api.docs.example.com/)
*   [마이페이지 기획](https://www.notion.so/250417-1d8599a329d5805b9976f26a47d128c2)

---

# 🙋🏻 리뷰 요구사항 (선택)
<!-- 코드 리뷰 요청이 필요한 부분을 구체적으로 작성해주세요. -->
- 이 PR의 주요 변경 사항이 적절한 방향인지 검토 부탁드립니다.
- 사용한 디자인 패턴이 적절한지 확인해 주세요.
- 코드 스타일 및 네이밍이 일관적인지 봐주세요.

---

# 🚀 PR 체크리스트
- [x] 내 코드가 정상적으로 동작하는지 테스트했나요?
- [x] 이 PR이 관련된 이슈와 연결되었나요?
- [x] 팀원들과 논의가 필요한 부분이 있나요?