### PR TITLE
fix: 보이스팩 생성 상태 체크 시 응답에 생성된 보이스팩 ID 포함하도록 수정

### DIFF
--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackService.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackService.kt
@@ -157,7 +157,6 @@ class VoicepackService(
         voicepackRequest.status = VoicepackRequestStatus.COMPLETED
         voicepackRequest.s3Path = outputPath
         voicepackRequest.completedAt = finishedTime
-        voicepackConvertRequestRepository.save(voicepackRequest)
         
         // 완성된 보이스팩 생성
         val voicepack = Voicepack(
@@ -167,6 +166,8 @@ class VoicepackService(
             createdAt = finishedTime
         )
         voicepackRepository.save(voicepack)
+        voicepackRequest.voicepackId = voicepack.id
+        voicepackConvertRequestRepository.save(voicepackRequest)
 
         // 사용권 부여
         grantUsageRight(voicepackRequest.author.id, voicepack.id)
@@ -532,7 +533,7 @@ class VoicepackService(
             }.run {
                 logger.debug("보이스팩 변환 상태 조회 성공: id={}, status={}", id, status)
                 VoicepackConvertStatusDto(
-                    id = id,
+                    voicepackId = voicepackId,
                     status = status.name,
                 )
             }

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/convert/VoicepackConvertRequest.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/convert/VoicepackConvertRequest.kt
@@ -30,7 +30,10 @@ data class VoicepackRequest(
     val createdAt: OffsetDateTime = OffsetDateTime.now(),
 
     @Column(name = "completed_at", nullable = true)
-    var completedAt: OffsetDateTime? = null
+    var completedAt: OffsetDateTime? = null,
+
+    @Column(name = "voicepack_id", nullable = true)
+    var voicepackId: Long? = null
 )
 
 enum class VoicepackRequestStatus {

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/convert/dto/VoicepackConvertRequestDto.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/convert/dto/VoicepackConvertRequestDto.kt
@@ -7,8 +7,8 @@ import io.swagger.v3.oas.annotations.media.Schema
 @Serializable
 @Schema(description = "보이스팩 생성 상태 조회 결과 DTO")
 data class VoicepackConvertStatusDto(
-    @field:Schema(description = "보이스팩 생성 요청의 고유 ID")
-    val id: Long,
+    @field:Schema(description = "해당 요청으로 생성된 보이스팩 고유 ID")
+    val voicepackId: Long?,
     
     @field:Schema(description = "생성 요청의 현재 상태 (PENDING, PROCESSING, COMPLETED, FAILED)")
     val status: String,


### PR DESCRIPTION
# 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈를 추가해주세요. (예: #123) 이슈 번호 앞에 Closes 작성하면 PR 머지할 때 자동으로 이슈가 닫힙니다.-->
Closes #

---

# ✨ 작업 사항
<!-- 이 PR에서 작업한 내용을 자유롭게 정리해주세요. -->
이제 보이스팩 생성 상태 체크 `convert/status/{requestId}`의 응답 중 `id`값 대신 `voicepackId`를 추가해, 이 값으로 `/example`을 수행할 수 있게 합니다.

---

# 📸 스크린샷 (선택)
<!-- 변경된 UI나 버그 수정 전후 비교 화면이 있다면 추가해주세요. -->
<!-- 이미지는 이슈 제출 후 드래그 앤 드롭으로 업로드할 수 있습니다. -->

---

# 🔗 참고 자료 (선택)
<!-- 관련 문서, 디자인 시안, API 문서 등이 있다면 추가해주세요. -->
- 예: [Figma 디자인](https://www.figma.com/), [API 문서](https://api.docs.example.com/)

---

# 🙋🏻 리뷰 요구사항 (선택)
<!-- 코드 리뷰 요청이 필요한 부분을 구체적으로 작성해주세요. -->
- 이 PR의 주요 변경 사항이 적절한 방향인지 검토 부탁드립니다.
- 사용한 디자인 패턴이 적절한지 확인해 주세요.
- 코드 스타일 및 네이밍이 일관적인지 봐주세요.

---

# 🚀 PR 체크리스트
- [ ] 내 코드가 정상적으로 동작하는지 테스트했나요?
- [x] 이 PR이 관련된 이슈와 연결되었나요?
- [x] 팀원들과 논의가 필요한 부분이 있나요?