### PR TITLE
feat: 보이스팩 필터링 기능 확장

### DIFF
--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/Voicepack.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/Voicepack.kt
@@ -31,7 +31,7 @@ data class Voicepack(
     var price: Int? = 1000,
 
     @Column(name = "is_public", nullable = false)
-    var isPublic: Boolean = true,
+    var isPublic: Boolean = false,
 
     @OneToMany(mappedBy = "voicepack", cascade = [CascadeType.REMOVE], orphanRemoval = true)
     val usageRights: MutableList<VoicepackUsageRight> = mutableListOf(),

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackController.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackController.kt
@@ -128,8 +128,8 @@ class VoicepackController(
     )
     @GetMapping("")
     fun getVoicepacks(
-        @Parameter(description = "사용자 ID ('mine', 'purchased' 필터 사용 시 필요)") @RequestParam(required = false) userId: Long?,
-        @Parameter(description = "필터 (all | mine | purchased), 기본값: all(공개된 보이스팩)") @RequestParam(required = false, defaultValue = "all") filter: String?
+        @Parameter(description = "사용자 ID ('mine', 'purchased', 'available' 필터 사용 시 필요)") @RequestParam(required = false) userId: Long?,
+        @Parameter(description = "필터 (all | mine | purchased | available), 기본값: all(공개된 보이스팩)") @RequestParam(required = false, defaultValue = "all") filter: String?
     ): ResponseEntity<List<VoicepackDto>> {
         try {
             val voicepacks = voicepackService.getVoicepacks(userId, filter)

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackService.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackService.kt
@@ -404,6 +404,10 @@ class VoicepackService(
                 if (userId == null) throw IllegalArgumentException("'purchased' 필터 사용 시 userId는 필수입니다.")
                 voicepackUsageRightRepository.findDistinctPurchasedVoicepacksByUserId(userId)
             }
+            "available" -> {
+                if (userId == null) throw IllegalArgumentException("'available' 필터 사용 시 userId는 필수입니다.")
+                voicepackUsageRightRepository.findByUserId(userId)
+            }
             else -> { // "all" 또는 그 외 (기본값)
                 voicepackRepository.findByIsPublicTrue() // 공개된 것만 조회
             }

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/usageright/VoicepackUsageRightRepository.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/usageright/VoicepackUsageRightRepository.kt
@@ -30,6 +30,7 @@ interface VoicepackUsageRightRepository : JpaRepository<VoicepackUsageRight, Lon
     @Query("SELECT COUNT(DISTINCT vur.voicepack.id) FROM VoicepackUsageRight vur WHERE vur.user.id = :userId AND vur.voicepack.author.id <> :userId")
     fun countPurchasedVoicepacksByUserId(@Param("userId") userId: Long): Int
 
-    // 특정 사용자가 보유한 모든 사용권 정보 조회 (페이지네이션 가능)
-    // fun findByUserId(userId: Long, pageable: Pageable): Page<VoicepackUsageRight>
+    // 특정 사용자가 사용 가능한 모든 보이스팩 엔티티 목록 조회
+    @Query("SELECT vur.voicepack FROM VoicepackUsageRight vur WHERE vur.user.id = :userId")
+    fun findByUserId(@Param("userId") userId: Long): List<Voicepack>
 } 


### PR DESCRIPTION
# 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈를 추가해주세요. (예: #123) 이슈 번호 앞에 Closes 작성하면 PR 머지할 때 자동으로 이슈가 닫힙니다.-->
Closes #

---

# ✨ 작업 사항
<!-- 이 PR에서 작업한 내용을 자유롭게 정리해주세요. -->
 - 보이스팩 검색 시 내가 사용권을 보유한 모든 팩을 조회할 수 있는 `available` 필터를 추가했습니다. 이는 기존의 `mine`과 `purchased`를 합한 것과 동일한 결과를 가져옵니다.
 - 보이스팩 생성 시 기본값을 비공개로 설정합니다.

---

# 📸 스크린샷 (선택)
<!-- 변경된 UI나 버그 수정 전후 비교 화면이 있다면 추가해주세요. -->
<!-- 이미지는 이슈 제출 후 드래그 앤 드롭으로 업로드할 수 있습니다. -->

---

# 🔗 참고 자료 (선택)
<!-- 관련 문서, 디자인 시안, API 문서 등이 있다면 추가해주세요. -->
- 예: [Figma 디자인](https://www.figma.com/), [API 문서](https://api.docs.example.com/)

---

# 🙋🏻 리뷰 요구사항 (선택)
<!-- 코드 리뷰 요청이 필요한 부분을 구체적으로 작성해주세요. -->
- 이 PR의 주요 변경 사항이 적절한 방향인지 검토 부탁드립니다.
- 사용한 디자인 패턴이 적절한지 확인해 주세요.
- 코드 스타일 및 네이밍이 일관적인지 봐주세요.

---

# 🚀 PR 체크리스트
- [x] 내 코드가 정상적으로 동작하는지 테스트했나요?
- [x] 이 PR이 관련된 이슈와 연결되었나요?
- [x] 팀원들과 논의가 필요한 부분이 있나요?