### PR TITLE
fix: 로그인 페이지 진입 시 자동 리다이렉트 및 랜딩페이지 버튼 조건부 처리

### DIFF
--- a/frontend/src/pages/Landing.js
+++ b/frontend/src/pages/Landing.js
@@ -81,7 +81,7 @@ const Landing = () => {
               만들고 공유하고 활용하세요
             </h1>
             <GradientButton
-              onClick={() => navigate('/sign-in')}
+              onClick={() => navigate(user ? '/voice-store' : '/sign-in')}
               className="text-lg py-3 px-8"
             >
               COVOS 시작하기
@@ -123,7 +123,7 @@ const Landing = () => {
           당신의 AI 보이스를 만들어보세요.
         </h2>
         <button
-          onClick={() => navigate('/sign-in')}
+          onClick={() => navigate(user ? '/voice-store' : '/sign-in')}
           className="bg-white text-blue-500 px-12 py-2 rounded font-semibold  relative z-10"
         >
           시작하기

--- a/frontend/src/pages/Landing.js
+++ b/frontend/src/pages/Landing.js
@@ -13,7 +13,6 @@ import { LogOut } from 'lucide-react';
 const Landing = () => {
   const navigate = useNavigate();
   const user = useUserStore((state) => state.user);
-  console.log(user);
   const clearUser = useUserStore((state) => state.clearUser);
 
   const handleLogout = () => {

--- a/frontend/src/pages/SignIn.js
+++ b/frontend/src/pages/SignIn.js
@@ -15,9 +15,11 @@ const SignIn = () => {
   const user = useUserStore((state) => state.user);
 
   // 로그인 상태라면 자동 리다이렉트
-  if (user) {
-    navigate('/voice-store');
-  }
+  useEffect(() => {
+    if (user) {
+      navigate('/voice-store');
+    }
+  }, [user, navigate]);
 
   const handleSignIn = () => {
     signin({ email, password });


### PR DESCRIPTION
# 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈를 추가해주세요. (예: #123) 이슈 번호 앞에 Closes 작성하면 PR 머지할 때 자동으로 이슈가 닫힙니다.-->
Closes #113 
---

# ✨ 작업 사항
<!-- 이 PR에서 작업한 내용을 자유롭게 정리해주세요. -->
- 로그인 상태에서도 랜딩페이지 상단에 '로그인' 버튼이 노출되는 버그 수정
- Zustand를 통해 유저 상태(`user`)를 가져와 로그인 여부에 따라 **조건부 렌더링** 적용
- 로그인 페이지(`SignIn`) 접근 시, 로그인된 사용자는 자동으로 `/voice-store`로 리다이렉트
- 랜딩페이지의 '시작하기' 버튼들도 로그인 여부에 따라 `/sign-in` 또는 `/voice-store`로 이동
---

# 📸 스크린샷 (선택)
<!-- 변경된 UI나 버그 수정 전후 비교 화면이 있다면 추가해주세요. -->
<!-- 이미지는 이슈 제출 후 드래그 앤 드롭으로 업로드할 수 있습니다. -->

---

# 🔗 참고 자료 (선택)
<!-- 관련 문서, 디자인 시안, API 문서 등이 있다면 추가해주세요. -->
- 예: [Figma 디자인](https://www.figma.com/), [API 문서](https://api.docs.example.com/)

---

# 🙋🏻 리뷰 요구사항 (선택)
<!-- 코드 리뷰 요청이 필요한 부분을 구체적으로 작성해주세요. -->
- 이 PR의 주요 변경 사항이 적절한 방향인지 검토 부탁드립니다.
- 사용한 디자인 패턴이 적절한지 확인해 주세요.
- 코드 스타일 및 네이밍이 일관적인지 봐주세요.

---

# 🚀 PR 체크리스트
- [x] 내 코드가 정상적으로 동작하는지 테스트했나요?
- [x] 이 PR이 관련된 이슈와 연결되었나요?
- [x] 팀원들과 논의가 필요한 부분이 있나요?