### PR TITLE
feat: 오늘의 명언 생성 관련 백엔드 API 및 내부 로직 구현

### DIFF
--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/config/HttpClientConfig.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/config/HttpClientConfig.kt
@@ -1,0 +1,40 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.config
+
+import io.ktor.client.* 
+import io.ktor.client.engine.java.* 
+import io.ktor.client.plugins.contentnegotiation.* 
+import io.ktor.client.plugins.logging.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.* 
+import kotlinx.serialization.json.Json
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class HttpClientConfig {
+
+    @Bean
+    fun httpClient(): HttpClient {
+        return HttpClient(Java) {
+            install(ContentNegotiation) { 
+                json(Json { 
+                    prettyPrint = true
+                    isLenient = true
+                    ignoreUnknownKeys = true // 알 수 없는 키 무시
+                })
+            }
+            
+            install(Logging) {
+                logger = Logger.DEFAULT
+                level = LogLevel.ALL // 필요에 따라 로그 레벨 조절 (INFO, HEADERS, BODY 등)
+                sanitizeHeader { header -> header == HttpHeaders.Authorization } // 민감한 헤더 로깅 제외
+            }
+            
+            // 필요하다면 추가적인 엔진 설정 (타임아웃 등) 가능
+            // engine {
+            //     connectTimeout = 10_000
+            //     socketTimeout = 10_000
+            // }
+        }
+    }
+} 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/config/HttpClientConfig.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/config/HttpClientConfig.kt
@@ -14,20 +14,25 @@ import org.springframework.context.annotation.Configuration
 class HttpClientConfig {
 
     @Bean
-    fun httpClient(): HttpClient {
+    fun ktorJson(): Json {
+        return Json { 
+            prettyPrint = true
+            isLenient = true
+            ignoreUnknownKeys = true
+        }
+    }
+
+    @Bean
+    fun httpClient(json: Json): HttpClient {
         return HttpClient(Java) {
             install(ContentNegotiation) { 
-                json(Json { 
-                    prettyPrint = true
-                    isLenient = true
-                    ignoreUnknownKeys = true // 알 수 없는 키 무시
-                })
+                json(json)
             }
             
             install(Logging) {
                 logger = Logger.DEFAULT
-                level = LogLevel.ALL // 필요에 따라 로그 레벨 조절 (INFO, HEADERS, BODY 등)
-                sanitizeHeader { header -> header == HttpHeaders.Authorization } // 민감한 헤더 로깅 제외
+                level = LogLevel.ALL
+                sanitizeHeader { header -> header == HttpHeaders.Authorization }
             }
             
             // 필요하다면 추가적인 엔진 설정 (타임아웃 등) 가능

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/QuoteController.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/QuoteController.kt
@@ -1,0 +1,32 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.quote
+
+import kr.ac.kookmin.cs.capstone.voicepack_platform.quote.dto.TodayQuoteRequest
+import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.synthesis.dto.VoicepackSynthesisSubmitResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import io.swagger.v3.oas.annotations.Parameter
+
+@RestController
+@RequestMapping("/api/quote")
+class QuoteController(
+    private val quoteService: QuoteService
+) {
+
+    @PostMapping("/today")
+    suspend fun generateTodayQuote(
+        @Parameter(description = "사용자 ID") userId: Long,
+        @RequestBody request: TodayQuoteRequest
+    ): ResponseEntity<VoicepackSynthesisSubmitResponse> {
+        val response = quoteService.generateQuoteAndSynthesize(userId, request)
+        // 서비스에서 오류 발생 시 id가 -1로 반환될 수 있으므로, 이에 따라 상태 코드 분기 가능
+        return if (response.id != -1L) {
+            ResponseEntity.ok(response)
+        } else {
+            // 실패 응답 처리 (예: 500 Internal Server Error 또는 400 Bad Request 등)
+            ResponseEntity.internalServerError().body(response)
+        }
+    }
+} 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/QuoteController.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/QuoteController.kt
@@ -15,7 +15,7 @@ class QuoteController(
     private val quoteService: QuoteService
 ) {
 
-    @PostMapping("/today")
+    @PostMapping("")
     suspend fun generateTodayQuote(
         @Parameter(description = "사용자 ID") userId: Long,
         @RequestBody request: TodayQuoteRequest

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/QuoteService.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/QuoteService.kt
@@ -1,0 +1,88 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.quote
+
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import kr.ac.kookmin.cs.capstone.voicepack_platform.quote.dto.*
+import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.VoicepackService
+import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.dto.VoicepackSynthesisRequest
+import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.synthesis.dto.VoicepackSynthesisSubmitResponse
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+
+@Service
+class QuoteService(
+    private val voicepackService: VoicepackService,
+    private val httpClient: HttpClient
+) {
+
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    // !!! 실제 구현 시에는 환경 변수나 설정 파일에서 안전하게 관리해야 합니다 !!!
+    @Value("\${openai.api.key}") // application.properties 등에서 설정
+    private lateinit var openAiApiKey: String
+
+    private val openAiApiUrl = "https://api.openai.com/v1/chat/completions"
+
+    suspend fun generateQuoteAndSynthesize(userId: Long, request: TodayQuoteRequest): VoicepackSynthesisSubmitResponse {
+        logger.info("오늘의 명언 생성 및 합성 요청 시작: userId={}, request={}", userId, request)
+
+        try {
+            // 1. OpenAI 프롬프트 생성
+            val prompt = createOpenAiPrompt(request.emotion, request.category)
+            logger.debug("생성된 OpenAI 프롬프트: {}", prompt)
+
+            // 2. OpenAI API 호출
+            val openAiRequest = OpenAIChatRequest(
+                model = "gpt-4.1-mini-2025-04-14", // 또는 다른 원하는 모델
+                messages = listOf(
+                    ChatMessage("system", "You are a helpful assistant that provides quotes."),
+                    ChatMessage("user", prompt)
+                )
+            )
+
+            val response: OpenAIChatResponse = httpClient.post(openAiApiUrl) {
+                contentType(ContentType.Application.Json)
+                header("Authorization", "Bearer $openAiApiKey")
+                setBody(openAiRequest)
+            }.body()
+
+            logger.debug("OpenAI API 응답 수신: {}", response)
+
+            // 3. 응답 파싱 (첫 번째 choice의 message content 사용)
+            val quoteText = response.choices.firstOrNull()?.message?.content?.trim()
+                ?: throw RuntimeException("OpenAI API로부터 유효한 명언을 받지 못했습니다.")
+
+            logger.info("추출된 명언: {}", quoteText)
+
+            // 4. VoicepackService를 통해 음성 합성 요청
+            val synthesisRequest = VoicepackSynthesisRequest(
+                voicepackId = request.voicepackId,
+                prompt = quoteText // OpenAI로부터 받은 명언을 합성할 텍스트로 사용
+            )
+
+            logger.info("음성 합성 요청 전달: userId={}, voicepackId={}, prompt='{}'", userId, request.voicepackId, quoteText)
+            return voicepackService.submitSynthesisRequest(userId, synthesisRequest)
+
+        } catch (e: Exception) {
+            logger.error("오늘의 명언 생성 또는 합성 중 오류 발생: userId={}, request={}", userId, request, e)
+
+            return VoicepackSynthesisSubmitResponse(
+                id = -1, // 실패 시 ID는 -1 또는 다른 식별 가능한 값으로 설정
+                message = "명언 생성 또는 음성 합성 중 오류가 발생했습니다: ${e.message}"
+            )
+        }
+    }
+
+    private fun createOpenAiPrompt(emotion: String, category: QuoteCategory): String {
+        val categoryDescription = when (category) {
+            QuoteCategory.KOREAN -> "한국의"
+            QuoteCategory.EASTERN -> "동양의"
+            QuoteCategory.WESTERN -> "서양의"
+        }
+        // 명언과 말한 사람만 요청하도록 프롬프트 구체화
+        return "현재 감정 상태는 '${emotion}'입니다. 이 감정 상태에 어울리는 ${categoryDescription} 유명한 명언 한 구절과 그 명언을 말한 사람을 알려주세요. 응답 형식은 '명언 구절 - 말한 사람' 형태로 한글로 답해주세요. 특수문자는 제외합니다."
+    }
+} 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/QuoteService.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/QuoteService.kt
@@ -4,7 +4,18 @@ import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.request.*
 import io.ktor.http.*
-import kr.ac.kookmin.cs.capstone.voicepack_platform.quote.dto.*
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.encodeToString
+import kr.ac.kookmin.cs.capstone.voicepack_platform.quote.dto.ChatMessage
+import kr.ac.kookmin.cs.capstone.voicepack_platform.quote.dto.FunctionParameters
+import kr.ac.kookmin.cs.capstone.voicepack_platform.quote.dto.FunctionTool
+import kr.ac.kookmin.cs.capstone.voicepack_platform.quote.dto.OpenAIChatRequest
+import kr.ac.kookmin.cs.capstone.voicepack_platform.quote.dto.OpenAIChatResponse
+import kr.ac.kookmin.cs.capstone.voicepack_platform.quote.dto.PropertyDetail
+import kr.ac.kookmin.cs.capstone.voicepack_platform.quote.dto.QuoteCategory
+import kr.ac.kookmin.cs.capstone.voicepack_platform.quote.dto.GoogleSearchResponse
+import kr.ac.kookmin.cs.capstone.voicepack_platform.quote.dto.TodayQuoteRequest
+import kr.ac.kookmin.cs.capstone.voicepack_platform.quote.dto.Tool
 import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.VoicepackService
 import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.dto.VoicepackSynthesisRequest
 import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.synthesis.dto.VoicepackSynthesisSubmitResponse
@@ -15,52 +26,126 @@ import org.springframework.stereotype.Service
 @Service
 class QuoteService(
     private val voicepackService: VoicepackService,
-    private val httpClient: HttpClient
+    private val httpClient: HttpClient,
+    private val json: Json
 ) {
 
     private val logger = LoggerFactory.getLogger(this::class.java)
 
-    // !!! 실제 구현 시에는 환경 변수나 설정 파일에서 안전하게 관리해야 합니다 !!!
-    @Value("\${openai.api.key}") // application.properties 등에서 설정
+    @Value("\${openai.api.key}")
     private lateinit var openAiApiKey: String
 
+    @Value("\${google.api.key}")
+    private lateinit var googleApiKey: String
+
+    @Value("\${google.cx.id}")
+    private lateinit var googleCxId: String
+
     private val openAiApiUrl = "https://api.openai.com/v1/chat/completions"
+    private val googleSearchApiUrl = "https://www.googleapis.com/customsearch/v1"
+
+    private val webSearchTool = Tool(
+        type = "function",
+        function = FunctionTool(
+            name = "web_search_for_quote",
+            description = "Searches the web for a famous quote based on emotion and category, and verifies its authenticity and speaker.",
+            parameters = FunctionParameters(
+                type = "object",
+                properties = mapOf(
+                    "emotion" to PropertyDetail(type = "string", description = "The current emotional state, e.g., happy, sad"),
+                    "category" to PropertyDetail(type = "string", description = "The category of the quote, e.g., KOREAN, EASTERN, WESTERN, or a general query term")
+                ),
+                required = listOf("emotion", "category")
+            )
+        )
+    )
 
     suspend fun generateQuoteAndSynthesize(userId: Long, request: TodayQuoteRequest): VoicepackSynthesisSubmitResponse {
         logger.info("오늘의 명언 생성 및 합성 요청 시작: userId={}, request={}", userId, request)
 
         try {
-            // 1. OpenAI 프롬프트 생성
-            val prompt = createOpenAiPrompt(request.emotion, request.category)
-            logger.debug("생성된 OpenAI 프롬프트: {}", prompt)
+            val initialPrompt = createOpenAiPrompt(request.emotion, request.category)
+            logger.debug("생성된 초기 OpenAI 프롬프트: {}", initialPrompt)
 
-            // 2. OpenAI API 호출
-            val openAiRequest = OpenAIChatRequest(
-                model = "gpt-4.1-mini-2025-04-14", // 또는 다른 원하는 모델
-                messages = listOf(
-                    ChatMessage("system", "You are a helpful assistant that provides quotes."),
-                    ChatMessage("user", prompt)
-                )
+            val initialMessages = mutableListOf(
+                ChatMessage("system", "You are a helpful assistant that provides quotes. If a web search is needed to find and verify a quote, you will call the 'web_search_for_quote' function. Provide the quote and its speaker in the format 'Quote - Speaker' in Korean."),
+                ChatMessage("user", initialPrompt)
             )
 
-            val response: OpenAIChatResponse = httpClient.post(openAiApiUrl) {
+            var openAiRequest = OpenAIChatRequest(
+                model = "gpt-4o-2024-08-06",
+                messages = initialMessages,
+                tools = listOf(webSearchTool),
+                tool_choice = "auto"
+            )
+
+            var apiResponse: OpenAIChatResponse = httpClient.post(openAiApiUrl) {
                 contentType(ContentType.Application.Json)
                 header("Authorization", "Bearer $openAiApiKey")
                 setBody(openAiRequest)
             }.body()
 
-            logger.debug("OpenAI API 응답 수신: {}", response)
+            logger.debug("첫 번째 OpenAI API 응답 수신: {}", apiResponse)
 
-            // 3. 응답 파싱 (첫 번째 choice의 message content 사용)
-            val quoteText = response.choices.firstOrNull()?.message?.content?.trim()
-                ?: throw RuntimeException("OpenAI API로부터 유효한 명언을 받지 못했습니다.")
+            val firstChoice = apiResponse.choices.firstOrNull()
+                ?: throw RuntimeException("OpenAI API로부터 유효한 응답을 받지 못했습니다. (첫 번째 호출)")
+
+            var quoteText: String?
+
+            if (firstChoice.finish_reason == "tool_calls" && firstChoice.message.tool_calls != null) {
+                logger.info("OpenAI가 웹 검색 함수 호출을 요청했습니다.")
+                val toolCall = firstChoice.message.tool_calls.firstOrNull { it.function.name == "web_search_for_quote" }
+
+                if (toolCall != null) {
+                    val searchArguments = json.decodeFromString<Map<String, String>>(toolCall.function.arguments)
+                    val emotionArg = searchArguments["emotion"] ?: ""
+                    val categoryArg = searchArguments["category"] ?: ""
+                    
+                    val searchQuery = "\'$categoryArg\' \'$emotionArg\' 관련된 유명한 명언과 말한 사람"
+                    logger.info("Google 검색 API 호출. 검색어: {}", searchQuery)
+                    val webSearchResultContent = performWebSearch(searchQuery)
+                    logger.info("웹 검색 결과: {}", webSearchResultContent)
+
+                    initialMessages.add(ChatMessage(role="assistant", content=null, tool_calls=firstChoice.message.tool_calls))
+                    initialMessages.add(
+                        ChatMessage(
+                            role = "tool",
+                            tool_call_id = toolCall.id,
+                            content = webSearchResultContent
+                        )
+                    )
+
+                    openAiRequest = OpenAIChatRequest(
+                        model = "gpt-4o-2024-08-06",
+                        messages = initialMessages
+                    )
+                    logger.info("웹 검색 결과를 포함하여 두 번째 OpenAI API 호출")
+                    apiResponse = httpClient.post(openAiApiUrl) {
+                        contentType(ContentType.Application.Json)
+                        header("Authorization", "Bearer $openAiApiKey")
+                        setBody(openAiRequest)
+                    }.body()
+                    logger.debug("두 번째 OpenAI API 응답 수신: {}", apiResponse)
+
+                    quoteText = apiResponse.choices.firstOrNull()?.message?.content?.trim()
+                } else {
+                    logger.warn("web_search_for_quote 함수 호출이 요청되었으나, 해당 tool_call을 찾을 수 없습니다.")
+                    quoteText = firstChoice.message.content?.trim()
+                }
+            } else {
+                logger.info("OpenAI가 웹 검색 없이 바로 응답했습니다.")
+                quoteText = firstChoice.message.content?.trim()
+            }
+
+            if (quoteText.isNullOrBlank()) {
+                throw RuntimeException("OpenAI API로부터 유효한 명언을 받지 못했습니다. (최종)")
+            }
 
             logger.info("추출된 명언: {}", quoteText)
 
-            // 4. VoicepackService를 통해 음성 합성 요청
             val synthesisRequest = VoicepackSynthesisRequest(
                 voicepackId = request.voicepackId,
-                prompt = quoteText // OpenAI로부터 받은 명언을 합성할 텍스트로 사용
+                prompt = quoteText
             )
 
             logger.info("음성 합성 요청 전달: userId={}, voicepackId={}, prompt='{}'", userId, request.voicepackId, quoteText)
@@ -68,9 +153,8 @@ class QuoteService(
 
         } catch (e: Exception) {
             logger.error("오늘의 명언 생성 또는 합성 중 오류 발생: userId={}, request={}", userId, request, e)
-
             return VoicepackSynthesisSubmitResponse(
-                id = -1, // 실패 시 ID는 -1 또는 다른 식별 가능한 값으로 설정
+                id = -1,
                 message = "명언 생성 또는 음성 합성 중 오류가 발생했습니다: ${e.message}"
             )
         }
@@ -78,11 +162,47 @@ class QuoteService(
 
     private fun createOpenAiPrompt(emotion: String, category: QuoteCategory): String {
         val categoryDescription = when (category) {
-            QuoteCategory.KOREAN -> "한국의"
-            QuoteCategory.EASTERN -> "동양의"
-            QuoteCategory.WESTERN -> "서양의"
+            QuoteCategory.KOREAN -> "한국"
+            QuoteCategory.EASTERN -> "동양"
+            QuoteCategory.WESTERN -> "서양"
         }
-        // 명언과 말한 사람만 요청하도록 프롬프트 구체화
-        return "현재 감정 상태는 '${emotion}'입니다. 이 감정 상태에 어울리는 ${categoryDescription} 유명한 명언 한 구절과 그 명언을 말한 사람을 알려주세요. 응답 형식은 '명언 구절 - 말한 사람' 형태로 한글로 답해주세요. 특수문자는 제외합니다."
+        return "현재 감정 상태는 '${emotion}'입니다. 이 감정에 어울리는 '${categoryDescription}'의 유명한 명언 한 구절과 그 명언을 말한 사람을 웹 검색을 통해 찾아보고, 검증된 정보를 바탕으로 알려주세요. 응답 형식은 '명언 구절 - 말한 사람' 형태로 한글로 답해주세요. 특수문자는 제외합니다. 적절한 결과가 없다면 일반적인 명언을 생성하고, 작자 미상으로 표시합니다. 출력은 별도의 설명 없이 반드시 '명언 구절 - 말한 사람' 형태로만 출력해주세요."
+    }
+
+    private suspend fun performWebSearch(query: String): String {
+        logger.info("Google Custom Search API 호출 시작. 검색어: {}", query)
+        try {
+            val response: GoogleSearchResponse = httpClient.get(googleSearchApiUrl) {
+                parameter("key", googleApiKey)
+                parameter("cx", googleCxId)
+                parameter("q", query)
+                parameter("num", 3)
+            }.body()
+
+            if (response.items.isNullOrEmpty()) {
+                logger.warn("Google 검색 결과가 없습니다. 검색어: {}", query)
+                return json.encodeToString(mapOf("error" to "No search results found."))
+            }
+
+            val searchResultsSummary = response.items.mapNotNull { item ->
+                mapOf(
+                    "title" to item.title,
+                    "snippet" to item.snippet,
+                    "link" to item.link
+                )
+            }
+            
+            if (searchResultsSummary.isEmpty()) {
+                logger.warn("유의미한 Google 검색 결과를 찾지 못했습니다. 검색어: {}", query)
+                return json.encodeToString(mapOf("message" to "Could not extract meaningful information from search results."))
+            }
+            
+            logger.info("Google 검색 성공. 가공된 결과: {}", searchResultsSummary)
+            return json.encodeToString(mapOf("searchResults" to searchResultsSummary))
+
+        } catch (e: Exception) {
+            logger.error("Google Custom Search API 호출 중 오류 발생. 검색어: {}, 오류: {}", query, e.message, e)
+            return json.encodeToString(mapOf("error" to "Failed to perform web search: ${e.message}"))
+        }
     }
 } 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/dto/GoogleSearchResponseDto.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/dto/GoogleSearchResponseDto.kt
@@ -1,0 +1,15 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.quote.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GoogleSearchResponse(
+    val items: List<GoogleSearchItem>? = null
+)
+
+@Serializable
+data class GoogleSearchItem(
+    val title: String? = null,
+    val link: String? = null,
+    val snippet: String? = null
+)

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/dto/OpenAIChatRequest.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/dto/OpenAIChatRequest.kt
@@ -6,11 +6,54 @@ import kotlinx.serialization.Serializable
 data class OpenAIChatRequest(
     val model: String,
     val messages: List<ChatMessage>,
-    val max_tokens: Int = 150 // 응답 최대 길이 제한
+    val max_tokens: Int = 150, // 응답 최대 길이 제한
+    val tools: List<Tool>? = null,
+    val tool_choice: String? = null // "none", "auto", or {"type": "function", "function": {"name": "my_function"}}
 )
 
 @Serializable
 data class ChatMessage(
-    val role: String, // "system", "user", "assistant"
-    val content: String
+    val role: String, // "system", "user", "assistant", "tool"
+    val content: String?,
+    val tool_calls: List<ToolCall>? = null,
+    val tool_call_id: String? = null
+)
+
+@Serializable
+data class Tool(
+    val type: String,
+    val function: FunctionTool
+)
+
+@Serializable
+data class FunctionTool(
+    val name: String,
+    val description: String,
+    val parameters: FunctionParameters
+)
+
+@Serializable
+data class FunctionParameters(
+    val type: String, // "object"
+    val properties: Map<String, PropertyDetail>,
+    val required: List<String>
+)
+
+@Serializable
+data class PropertyDetail(
+    val type: String,
+    val description: String? = null
+)
+
+@Serializable
+data class ToolCall(
+    val id: String,
+    val type: String, // "function"
+    val function: FunctionCallData
+)
+
+@Serializable
+data class FunctionCallData(
+    val name: String,
+    val arguments: String // JSON string
 ) 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/dto/OpenAIChatRequest.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/dto/OpenAIChatRequest.kt
@@ -1,0 +1,16 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.quote.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OpenAIChatRequest(
+    val model: String,
+    val messages: List<ChatMessage>,
+    val max_tokens: Int = 150 // 응답 최대 길이 제한
+)
+
+@Serializable
+data class ChatMessage(
+    val role: String, // "system", "user", "assistant"
+    val content: String
+) 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/dto/OpenAIChatResponse.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/dto/OpenAIChatResponse.kt
@@ -9,7 +9,7 @@ data class OpenAIChatResponse(
     val created: Long,
     val model: String,
     val choices: List<Choice>,
-    val usage: Usage
+    val usage: Usage?
 )
 
 @Serializable

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/dto/OpenAIChatResponse.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/dto/OpenAIChatResponse.kt
@@ -1,0 +1,27 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.quote.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class OpenAIChatResponse(
+    val id: String,
+    val `object`: String,
+    val created: Long,
+    val model: String,
+    val choices: List<Choice>,
+    val usage: Usage
+)
+
+@Serializable
+data class Choice(
+    val index: Int,
+    val message: ChatMessage,
+    val finish_reason: String
+)
+
+@Serializable
+data class Usage(
+    val prompt_tokens: Int,
+    val completion_tokens: Int,
+    val total_tokens: Int
+) 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/dto/QuoteCategory.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/dto/QuoteCategory.kt
@@ -1,0 +1,7 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.quote.dto
+
+enum class QuoteCategory {
+    KOREAN, // 한국
+    EASTERN, // 동양
+    WESTERN // 서양
+} 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/dto/TodayQuoteRequest.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/dto/TodayQuoteRequest.kt
@@ -1,0 +1,7 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.quote.dto
+
+data class TodayQuoteRequest(
+    val emotion: String, // 현재 감정 상태
+    val category: QuoteCategory, // 원하는 명언 분야
+    val voicepackId: Long // 음성 합성에 사용할 보이스팩 ID
+) 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackService.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackService.kt
@@ -52,18 +52,9 @@ class VoicepackService(
     private val creditService: CreditService,
     private val saleRepository: SaleRepository,
     private val s3PresignedUrlGenerator: S3PresignedUrlGenerator,
-    private val rabbitTemplate: RabbitTemplate
+    private val rabbitTemplate: RabbitTemplate,
+    private val httpClient: HttpClient
 ) {
-
-    private val httpClient = HttpClient(Java) {
-        install(ContentNegotiation) { json() }
-
-        install(Logging) {
-            logger = Logger.DEFAULT
-            level = LogLevel.ALL
-            sanitizeHeader { header -> header == HttpHeaders.Authorization }
-        }
-    }
 
     private val logger = LoggerFactory.getLogger(this::class.java)
     private val objectMapper = jacksonObjectMapper() // JSON 변환기

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/service/VoicepackCallbackService.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/service/VoicepackCallbackService.kt
@@ -13,6 +13,7 @@ import software.amazon.awssdk.services.sqs.SqsClient
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest
 import software.amazon.awssdk.services.sqs.model.Message
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
+import org.springframework.beans.factory.annotation.Qualifier
 
 @Service
 class VoicepackCallbackService(
@@ -21,7 +22,7 @@ class VoicepackCallbackService(
     private val voicepackService: VoicepackService,
     private val sqsClient: SqsClient,
     private val objectMapper: ObjectMapper,
-    private val scope: CoroutineScope
+    @Qualifier("applicationScope") private val scope: CoroutineScope
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 


### PR DESCRIPTION
# 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈를 추가해주세요. (예: #123) 이슈 번호 앞에 Closes 작성하면 PR 머지할 때 자동으로 이슈가 닫힙니다.-->
Closes #115 

---

# ✨ 작업 사항
<!-- 이 PR에서 작업한 내용을 자유롭게 정리해주세요. -->

현재 감정 상태를 입력하고 원하는 보이스팩과 지역(한국, 동양, 서양)을 선택하면 감정 상태에 어울리는 해당 지역의 명언을 음성으로 생성합니다.
해당 명언은 환각을 방지하기 위해 웹 검색을 먼저 진행하고 그 안에서 관련 명언을 찾습니다.
관련 명언이 없는 경우 적절한 문장을 생성 후, '작자 미상'으로 표기합니다.

`POST /api/quote`로 호출하며, 아래 내용을 Body에 Json으로 담습니다:
```
data class TodayQuoteRequest(
    val emotion: String, // 현재 감정 상태
    val category: QuoteCategory, // 원하는 명언 분야 (`KOREAN`, `EASTERN`, `WESTERN`) 문자열로 입력
    val voicepackId: Long // 음성 합성에 사용할 보이스팩 ID
) 
```
응답 처리는 기존 베이직 보이스 기능과 동일하게 폴링합니다.

---

# 🚀 PR 체크리스트
- [x] 내 코드가 정상적으로 동작하는지 테스트했나요?
- [x] 이 PR이 관련된 이슈와 연결되었나요?
- [x] 팀원들과 논의가 필요한 부분이 있나요?