### PR TITLE
fix: Bean 충돌 문제 해결

### DIFF
--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/aiAssistant/service/AiAssistantCallbackService.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/aiAssistant/service/AiAssistantCallbackService.kt
@@ -13,6 +13,7 @@ import software.amazon.awssdk.services.sqs.SqsClient
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest
 import software.amazon.awssdk.services.sqs.model.Message
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
+import org.springframework.beans.factory.annotation.Qualifier
 
 @Service
 class AiAssistantCallbackService(
@@ -20,7 +21,7 @@ class AiAssistantCallbackService(
     private val aiAssistantService: AiAssistantService,
     private val sqsClient: SqsClient,
     private val objectMapper: ObjectMapper,
-    private val scope: CoroutineScope
+    @Qualifier("applicationScope") private val scope: CoroutineScope
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/service/VoicepackCallbackService.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/service/VoicepackCallbackService.kt
@@ -22,7 +22,7 @@ class VoicepackCallbackService(
     private val voicepackService: VoicepackService,
     private val sqsClient: SqsClient,
     private val objectMapper: ObjectMapper,
-    @Qualifier("applicationScope") private val scope: CoroutineScope
+    private val scope: CoroutineScope
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/service/VoicepackCallbackService.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/service/VoicepackCallbackService.kt
@@ -22,7 +22,7 @@ class VoicepackCallbackService(
     private val voicepackService: VoicepackService,
     private val sqsClient: SqsClient,
     private val objectMapper: ObjectMapper,
-    private val scope: CoroutineScope
+    @Qualifier("applicationScope") private val scope: CoroutineScope
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
 


### PR DESCRIPTION
# 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈를 추가해주세요. (예: #123) 이슈 번호 앞에 Closes 작성하면 PR 머지할 때 자동으로 이슈가 닫힙니다.-->
#115 

---

# ✨ 작업 사항
<!-- 이 PR에서 작업한 내용을 자유롭게 정리해주세요. -->

- 명언 로직에서 코루틴 사용 시 특정 빈을 명시하는 방식으로 진행했으나, 다른 코드에서 사용하는 ktor 패키지의 `HttpClient`가 `CoroutineScope`의 구현체로 만들어져 `@Qualifier`가 없는 다른 소스에서 `NoUniqueBeanDefinitionException` 발생함. 
- 해결 방식으로 스프링의 자동 DI를 활용함.

---
