### PR TITLE
fix: 오늘의 명언 생성 API에서 사용자 ID를 @RequestParam으로 변경하고, 응답 URI 생성 로직 추가

### DIFF
--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/QuoteController.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/quote/QuoteController.kt
@@ -7,7 +7,9 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.RequestParam
 import io.swagger.v3.oas.annotations.Parameter
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder
 
 @RestController
 @RequestMapping("/api/quote")
@@ -17,13 +19,23 @@ class QuoteController(
 
     @PostMapping("")
     suspend fun generateTodayQuote(
-        @Parameter(description = "사용자 ID") userId: Long,
+        @Parameter(description = "사용자 ID") @RequestParam userId: Long,
         @RequestBody request: TodayQuoteRequest
     ): ResponseEntity<VoicepackSynthesisSubmitResponse> {
+        // 서비스 호출 전에 현재 컨텍스트 경로 미리 추출
+        val baseUrl = ServletUriComponentsBuilder.fromCurrentContextPath().toUriString()
+        
         val response = quoteService.generateQuoteAndSynthesize(userId, request)
         // 서비스에서 오류 발생 시 id가 -1로 반환될 수 있으므로, 이에 따라 상태 코드 분기 가능
         return if (response.id != -1L) {
-            ResponseEntity.ok(response)
+            // 미리 추출한 baseUrl 사용하여 URI 생성
+            val locationUri = ServletUriComponentsBuilder
+                .fromUriString(baseUrl)
+                .path("/api/voicepack/synthesis/status/{id}")
+                .buildAndExpand(response.id)
+                .toUri()
+                
+            return ResponseEntity.accepted().location(locationUri).body(response)
         } else {
             // 실패 응답 처리 (예: 500 Internal Server Error 또는 400 Bad Request 등)
             ResponseEntity.internalServerError().body(response)


### PR DESCRIPTION
# 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈를 추가해주세요. (예: #123) 이슈 번호 앞에 Closes 작성하면 PR 머지할 때 자동으로 이슈가 닫힙니다.-->
Issue #115

---

# ✨ 작업 사항
<!-- 이 PR에서 작업한 내용을 자유롭게 정리해주세요. -->

- 응답 시, 서비스 호출 결과에 따라 생성된 URI를 포함하여 반환하도록 로직을 추가함.
  - 베이직 보이스 기능과 동일하게 `Location` 헤더 정보를 추가함.

---