### PR TITLE
fix: S3 PUT Presigned URL 생성 및 보이스팩 변환 로직 개선

### DIFF
--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/common/util/S3PresignedUrlGenerator.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/common/util/S3PresignedUrlGenerator.kt
@@ -6,8 +6,10 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest
 import java.time.Duration
 
 /**
@@ -22,7 +24,7 @@ class S3PresignedUrlGenerator(
 ) {
 
     /**
-     * S3 객체에 대한 Presigned URL을 생성합니다.
+     * S3 객체에 대한 GET Presigned URL을 생성합니다.
      *
      * @param objectKey S3 객체 키
      * @param expirationInMinutes URL 만료 시간(분)
@@ -47,6 +49,35 @@ class S3PresignedUrlGenerator(
                     .build()
 
                 return presigner.presignGetObject(presignRequest).url().toString()
+            }
+    }
+    
+    /**
+     * S3 객체에 대한 PUT Presigned URL을 생성합니다.
+     *
+     * @param objectKey S3 객체 키
+     * @param expirationInMinutes URL 만료 시간(분)
+     * @return Presigned URL 문자열
+     */
+    fun generatePutPresignedUrl(objectKey: String, expirationInMinutes: Long = 10): String {
+        val credentials = AwsBasicCredentials.create(accessKey, secretKey)
+        val region = Region.of(regionName)
+
+        S3Presigner.builder()
+            .region(region)
+            .credentialsProvider(StaticCredentialsProvider.create(credentials))
+            .build().use { presigner ->
+                val putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(objectKey)
+                    .build()
+
+                val presignRequest = PutObjectPresignRequest.builder()
+                    .signatureDuration(Duration.ofMinutes(expirationInMinutes))
+                    .putObjectRequest(putObjectRequest)
+                    .build()
+
+                return presigner.presignPutObject(presignRequest).url().toString()
             }
     }
 } 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/video2voicepack/Video2VoicepackService.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/video2voicepack/Video2VoicepackService.kt
@@ -1,45 +1,74 @@
 package kr.ac.kookmin.cs.capstone.voicepack_platform.video2voicepack
 
+import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.VoicepackService
 import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.dto.VoicepackConvertRequest
 import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.dto.VoicepackConvertResponse
-import kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.VoicepackService
+import kr.ac.kookmin.cs.capstone.voicepack_platform.video2voicepack.SimpleMultipartFile
+import kr.ac.kookmin.cs.capstone.voicepack_platform.video2voicepack.presignedurl.PresignedUrlService
 import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
-import kr.ac.kookmin.cs.capstone.voicepack_platform.video2voicepack.SimpleMultipartFile
 import java.io.File
 import java.io.FileOutputStream
 import java.net.URI
 import java.nio.file.Files
+import org.slf4j.LoggerFactory
 
 @Service
 class Video2VoicepackService(
-    private val voicepackService: VoicepackService
+    private val voicepackService: VoicepackService,
+    private val presignedUrlService: PresignedUrlService
 ) {
-    suspend fun convertVideo2Voicepack(userId: Long, name: String, presignedUrl: String): VoicepackConvertResponse {
-        // 1. presignedUrl로 파일 다운로드
-        val tempFile = File.createTempFile("video2voicepack_", ".wav")
+    private val logger = LoggerFactory.getLogger(this::class.java)
+    
+    suspend fun convertVideo2Voicepack(userId: Long, name: String, putUrl: String): VoicepackConvertResponse {
+        // PUT URL로 엔티티 조회 (존재하는지 및 만료되지 않았는지 확인)
+        val urlDetail = presignedUrlService.getPresignedUrlDetailByPutUrl(putUrl)
+        val getUrl = urlDetail.getUrl
+        
+        logger.info("조회된 GET URL: {}", getUrl)
+        
+        // 임시 파일 생성
+        val tempFile = File.createTempFile("video_", ".mp4")
         try {
-            URI(presignedUrl).toURL().openStream().use { input ->
+            // URL로부터 파일 다운로드
+            URI(getUrl).toURL().openStream().use { input ->
                 FileOutputStream(tempFile).use { output ->
                     input.copyTo(output)
                 }
             }
-            // 2. MultipartFile로 변환
+            logger.info("파일 다운로드 완료: {}, 크기: {}", tempFile.absolutePath, tempFile.length())
+
+            // MultipartFile로 변환 (SimpleMultipartFile 사용)
             val fileBytes = Files.readAllBytes(tempFile.toPath())
-            val multipartFile: MultipartFile = SimpleMultipartFile(
-                name,
-                "audio/wav",
+            val multipartFile = SimpleMultipartFile(
+                tempFile.name,
+                "video/mp4",
                 fileBytes
             )
-            // 3. 기존 보이스팩 생성 로직 호출
-            val request = VoicepackConvertRequest(name, multipartFile, isVideoBased = true, tempFilePath = tempFile.absolutePath, imageFile = null, categories = listOf(""))
-            val response = voicepackService.convertVoicepack(userId, request)
-            // 4. 생성된 보이스팩의 isVideoBased=true, isPublic=false로 강제 (DB 반영)
-            // (VoicepackService에서 생성 후 후처리 필요)
-            // 별도 후처리 메소드 호출 또는 콜백에서 처리 필요
-            // 5. 반환
-            return response
-        } finally {
+
+            // 보이스팩 변환 요청
+            val convertRequest = VoicepackConvertRequest(
+                name = name,
+                voiceFile = multipartFile,
+                isVideoBased = true,
+                tempFilePath = tempFile.absolutePath,
+                imageFile = null,
+                categories = listOf("영상 기반")
+            )
+            logger.info("보이스팩 변환 요청: userId={}, name={}, fileSize={}", userId, name, multipartFile.size)
+
+            return voicepackService.convertVoicepack(userId, convertRequest)
+        } catch (e: Exception) {
+            // 오류 발생 시 VoicepackService가 호출되지 않으므로, 여기서 임시 파일 삭제
+            if (tempFile.exists()) {
+                try {
+                    tempFile.delete()
+                    logger.info("오류 발생으로 임시 파일 삭제: {}", tempFile.absolutePath)
+                } catch (deleteError: Exception) {
+                    logger.warn("임시 파일 삭제 실패: {}", tempFile.absolutePath, deleteError)
+                }
+            }
+            throw e
         }
     }
 }

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/video2voicepack/presignedurl/PresignedUrlDto.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/video2voicepack/presignedurl/PresignedUrlDto.kt
@@ -1,0 +1,15 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.video2voicepack.presignedurl
+
+import java.time.LocalDateTime
+
+data class PresignedUrlResponseDto(
+    val putUrl: String,
+    val expiresAt: LocalDateTime
+)
+
+data class PresignedUrlDetailDto(
+    val putUrl: String,
+    val getUrl: String,
+    val expiresAt: LocalDateTime,
+    val createdAt: LocalDateTime
+) 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/video2voicepack/presignedurl/PresignedUrlEntity.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/video2voicepack/presignedurl/PresignedUrlEntity.kt
@@ -1,0 +1,39 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.video2voicepack.presignedurl
+
+import jakarta.persistence.*
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "presigned_urls")
+class PresignedUrlEntity(
+    @Id
+    @Column(nullable = false, length = 1024)
+    val putUrl: String,
+    
+    @Column(nullable = false, length = 1024)
+    val getUrl: String,
+    
+    @Column(nullable = false)
+    val expiresAt: LocalDateTime,
+    
+    @CreationTimestamp
+    @Column(nullable = false, updatable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now()
+) {
+    fun toDetailDto(): PresignedUrlDetailDto {
+        return PresignedUrlDetailDto(
+            putUrl = putUrl,
+            getUrl = getUrl,
+            expiresAt = expiresAt,
+            createdAt = createdAt
+        )
+    }
+    
+    fun toResponseDto(): PresignedUrlResponseDto {
+        return PresignedUrlResponseDto(
+            putUrl = putUrl,
+            expiresAt = expiresAt
+        )
+    }
+} 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/video2voicepack/presignedurl/PresignedUrlRepository.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/video2voicepack/presignedurl/PresignedUrlRepository.kt
@@ -1,0 +1,7 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.video2voicepack.presignedurl
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface PresignedUrlRepository : JpaRepository<PresignedUrlEntity, String> 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/video2voicepack/presignedurl/PresignedUrlService.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/video2voicepack/presignedurl/PresignedUrlService.kt
@@ -1,0 +1,53 @@
+package kr.ac.kookmin.cs.capstone.voicepack_platform.video2voicepack.presignedurl
+
+import kr.ac.kookmin.cs.capstone.voicepack_platform.common.util.S3PresignedUrlGenerator
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class PresignedUrlService(
+    private val presignedUrlRepository: PresignedUrlRepository,
+    private val s3PresignedUrlGenerator: S3PresignedUrlGenerator
+) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    @Transactional
+    fun generateAndSavePresignedUrls(expirationInMinutes: Long = 10): String {
+        // 객체 키 생성 (랜덤)
+        val objectKey = "video2voicepack/${java.util.UUID.randomUUID()}"
+        
+        // S3 Presigned PUT/GET URL 생성
+        val putUrl = s3PresignedUrlGenerator.generatePutPresignedUrl(objectKey, expirationInMinutes)
+        val getUrl = s3PresignedUrlGenerator.generatePresignedUrl(objectKey, expirationInMinutes)
+        
+        // 만료 시간 계산
+        val expiresAt = LocalDateTime.now().plusMinutes(expirationInMinutes)
+        
+        // 엔티티 생성 및 저장
+        val presignedUrlEntity = PresignedUrlEntity(
+            putUrl = putUrl,
+            getUrl = getUrl,
+            expiresAt = expiresAt
+        )
+        
+        presignedUrlRepository.save(presignedUrlEntity)
+        logger.info("새로운 Presigned URL 생성 완료: putUrl={}, getUrl={}", putUrl, getUrl)
+        
+        return putUrl
+    }
+    
+    @Transactional(readOnly = true)
+    fun getPresignedUrlDetailByPutUrl(putUrl: String): PresignedUrlDetailDto {
+        val presignedUrlEntity = presignedUrlRepository.findById(putUrl)
+            .orElseThrow { IllegalArgumentException("해당하는 PUT URL로 저장된 Presigned URL이 없습니다: $putUrl") }
+            
+        // 만료 시간 확인
+        if (presignedUrlEntity.expiresAt.isBefore(LocalDateTime.now())) {
+            throw IllegalStateException("Presigned URL이 만료되었습니다. putUrl: $putUrl, 만료시간: ${presignedUrlEntity.expiresAt}")
+        }
+        
+        return presignedUrlEntity.toDetailDto()
+    }
+} 


### PR DESCRIPTION
# 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈를 추가해주세요. (예: #123) 이슈 번호 앞에 Closes 작성하면 PR 머지할 때 자동으로 이슈가 닫힙니다.-->
#119 

---

# ✨ 작업 사항
<!-- 이 PR에서 작업한 내용을 자유롭게 정리해주세요. -->
- S3 객체에 대한 PUT Presigned URL을 생성하는 기능을 추가하였습니다.
- `Video2VoicepackController`에서 Presigned URL 발급 로직을 `PresignedUrlService`로 분리하였습니다.
- `Video2VoicepackService`에서 PUT URL을 사용하여 파일 다운로드 및 보이스팩 변환 로직을 개선하였습니다.


---

# 📸 스크린샷 (선택)
<!-- 변경된 UI나 버그 수정 전후 비교 화면이 있다면 추가해주세요. -->
<!-- 이미지는 이슈 제출 후 드래그 앤 드롭으로 업로드할 수 있습니다. -->

---

# 🔗 참고 자료 (선택)
<!-- 관련 문서, 디자인 시안, API 문서 등이 있다면 추가해주세요. -->
- 예: [Figma 디자인](https://www.figma.com/), [API 문서](https://api.docs.example.com/)

---

# 🙋🏻 리뷰 요구사항 (선택)
<!-- 코드 리뷰 요청이 필요한 부분을 구체적으로 작성해주세요. -->
- 이 PR의 주요 변경 사항이 적절한 방향인지 검토 부탁드립니다.
- 사용한 디자인 패턴이 적절한지 확인해 주세요.
- 코드 스타일 및 네이밍이 일관적인지 봐주세요.

---

# 🚀 PR 체크리스트
- [x] 내 코드가 정상적으로 동작하는지 테스트했나요?
- [x] 이 PR이 관련된 이슈와 연결되었나요?
- [x] 팀원들과 논의가 필요한 부분이 있나요?