### PR TITLE
fix: Presigned URL 엔티티 및 리포지토리 개선

### DIFF
--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/video2voicepack/presignedurl/PresignedUrlEntity.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/video2voicepack/presignedurl/PresignedUrlEntity.kt
@@ -2,16 +2,25 @@ package kr.ac.kookmin.cs.capstone.voicepack_platform.video2voicepack.presignedur
 
 import jakarta.persistence.*
 import org.hibernate.annotations.CreationTimestamp
+import java.security.MessageDigest
 import java.time.LocalDateTime
+import java.util.Base64
 
 @Entity
-@Table(name = "presigned_urls")
+@Table(name = "presigned_urls", 
+       indexes = [Index(name = "idx_put_url_hash", columnList = "putUrlHash", unique = true)])
 class PresignedUrlEntity(
     @Id
-    @Column(nullable = false, length = 1024)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+    
+    @Column(nullable = false, columnDefinition = "TEXT")
     val putUrl: String,
     
-    @Column(nullable = false, length = 1024)
+    @Column(nullable = false, length = 64)
+    val putUrlHash: String = calculateHash(putUrl),
+    
+    @Column(nullable = false, columnDefinition = "TEXT")
     val getUrl: String,
     
     @Column(nullable = false)
@@ -21,6 +30,14 @@ class PresignedUrlEntity(
     @Column(nullable = false, updatable = false)
     val createdAt: LocalDateTime = LocalDateTime.now()
 ) {
+    companion object {
+        // 문자열의 SHA-256 해시를 계산하는 함수
+        fun calculateHash(input: String): String {
+            val bytes = MessageDigest.getInstance("SHA-256").digest(input.toByteArray())
+            return Base64.getEncoder().encodeToString(bytes)
+        }
+    }
+    
     fun toDetailDto(): PresignedUrlDetailDto {
         return PresignedUrlDetailDto(
             putUrl = putUrl,

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/video2voicepack/presignedurl/PresignedUrlRepository.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/video2voicepack/presignedurl/PresignedUrlRepository.kt
@@ -2,6 +2,10 @@ package kr.ac.kookmin.cs.capstone.voicepack_platform.video2voicepack.presignedur
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import java.util.Optional
 
 @Repository
-interface PresignedUrlRepository : JpaRepository<PresignedUrlEntity, String> 
+interface PresignedUrlRepository : JpaRepository<PresignedUrlEntity, Long> {
+    fun findByPutUrl(putUrl: String): Optional<PresignedUrlEntity>
+    fun findByPutUrlHash(putUrlHash: String): Optional<PresignedUrlEntity>
+} 


### PR DESCRIPTION


# 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈를 추가해주세요. (예: #123) 이슈 번호 앞에 Closes 작성하면 PR 머지할 때 자동으로 이슈가 닫힙니다.-->
#119

---

# ✨ 작업 사항
<!-- 이 PR에서 작업한 내용을 자유롭게 정리해주세요. -->
 - 기존 Presigned URL 자체를 key로 잡으니, MySQL의 최대 키 길이 제한에 걸리는 문제 발생하였습니다. 따라서 대리키 도입하였습니다.
- PUT URL로 GET URL을 빠르게 찾기 위해 PresignedUrlEntity에 SHA-256 해시 계산 기능을 추가하여 putUrlHash 필드를 자동으로 생성하도록 수정하였습니다.
- PresignedUrlRepository에 putUrlHash로 검색하는 기능을 추가하였습니다.
- PresignedUrlService에서 PUT URL을 해시로 먼저 검색하고, 실패 시 원본 URL로 검색하는 로직을 추가하여 성능을 개선하였습니다.

---
