### PR TITLE
feat: 사용자 ID에 따른 보이스팩 조회 기능 개선 및 영상 기반 필터링 추가

### DIFF
--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackController.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackController.kt
@@ -334,9 +334,10 @@ class VoicepackController(
     )
     @GetMapping("/usage-right")
     fun getUserVoicepacks(
-        @Parameter(description = "사용자 ID") @RequestParam userId: Long
+        @Parameter(description = "사용자 ID") @RequestParam userId: Long,
+        @Parameter(description = "영상 기반 보이스팩 여부") @RequestParam(required = false, defaultValue = "false") isVideoBased: Boolean
     ): ResponseEntity<List<VoicepackUsageRightBriefDto>> {
-        val voicepacks = voicepackService.getVoicepacksByUserId(userId)
+        val voicepacks = voicepackService.getVoicepacksByUserId(userId, isVideoBased)
         return ResponseEntity.ok(voicepacks)
     }
 

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackService.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/VoicepackService.kt
@@ -598,9 +598,9 @@ class VoicepackService(
     /**
      * 사용자가 보유한 보이스팩 목록 조회
      */
-    fun getVoicepacksByUserId(userId: Long): List<VoicepackUsageRightBriefDto> {
+    fun getVoicepacksByUserId(userId: Long, isVideoBased: Boolean): List<VoicepackUsageRightBriefDto> {
         logger.info("사용자의 보이스팩 목록 조회: userId={}", userId)
-        return voicepackUsageRightRepository.findVoicepackDtosByUserId(userId)
+        return voicepackUsageRightRepository.findVoicepackDtosByUserIdAndIsVideoBased(userId, isVideoBased)
     }
 
     /**

--- a/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/usageright/VoicepackUsageRightRepository.kt
+++ b/backend/src/main/kotlin/kr/ac/kookmin/cs/capstone/voicepack_platform/voicepack/usageright/VoicepackUsageRightRepository.kt
@@ -22,6 +22,15 @@ interface VoicepackUsageRightRepository : JpaRepository<VoicepackUsageRight, Lon
     """)
     fun findVoicepackDtosByUserId(@Param("userId") userId: Long): List<VoicepackUsageRightBriefDto>
 
+    @Query("""
+        SELECT new kr.ac.kookmin.cs.capstone.voicepack_platform.voicepack.usageright.VoicepackUsageRightBriefDto(
+            v.voicepack.id,
+            v.voicepack.name
+        )
+        FROM VoicepackUsageRight v  
+        WHERE v.user.id = :userId AND v.voicepack.isVideoBased = :isVideoBased
+    """)
+    fun findVoicepackDtosByUserIdAndIsVideoBased(@Param("userId") userId: Long, @Param("isVideoBased") isVideoBased: Boolean): List<VoicepackUsageRightBriefDto>
     // 사용자가 구매한 (즉, 자신이 생성하지 않은) 보이스팩 엔티티 목록 조회
     @Query("SELECT DISTINCT vur.voicepack FROM VoicepackUsageRight vur WHERE vur.user.id = :userId AND vur.voicepack.author.id <> :userId")
     fun findDistinctPurchasedVoicepacksByUserId(@Param("userId") userId: Long): List<Voicepack>


### PR DESCRIPTION
# 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈를 추가해주세요. (예: #123) 이슈 번호 앞에 Closes 작성하면 PR 머지할 때 자동으로 이슈가 닫힙니다.-->
#119 

---

# ✨ 작업 사항
<!-- 이 PR에서 작업한 내용을 자유롭게 정리해주세요. -->
- 영상 기반 보이스팩을 리멤버 보이스에서만 활용할 수 있도록 베이직 보이스용 사용권 조회 로직을 수정해 분리했습니다.
  - 기존 베이직 보이스에서 사용하는 api 요청은 변경하지 않아도 됩니다.
  - 리멤버 보이스 기능에서는 `GET /api/voicepack/usage-right?userId={userId}&isVideoBased=true`를 사용합니다. 

- VoicepackController에서 사용자 ID와 영상 기반 여부를 파라미터로 받아 보이스팩을 조회하도록 수정하였습니다.
- VoicepackService에서 사용자 ID와 영상 기반 여부를 기반으로 보이스팩 목록을 반환하도록 로직을 변경하였습니다.
- VoicepackUsageRightRepository에 영상 기반 여부를 고려한 쿼리를 추가하였습니다.

---

# 📸 스크린샷 (선택)
<!-- 변경된 UI나 버그 수정 전후 비교 화면이 있다면 추가해주세요. -->
<!-- 이미지는 이슈 제출 후 드래그 앤 드롭으로 업로드할 수 있습니다. -->
<img width="752" alt="image" src="https://github.com/user-attachments/assets/2a7bdf35-e1c7-4203-9ac1-a543f0494d17" />

---

# 🔗 참고 자료 (선택)
<!-- 관련 문서, 디자인 시안, API 문서 등이 있다면 추가해주세요. -->
- 병합 후 Swagger 참고 바랍니다.
